### PR TITLE
Feature/tailwindcss_커스텀_컬러_설정_#168

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,14 @@ const withMT = require('@material-tailwind/react/utils/withMT');
 module.exports = withMT({
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        mainBlack: '#131316',
+        middleBlack: '#18181C',
+        subBlack: '#26262C',
+        pointBlue: '#4CEEF9',
+      },
+    },
   },
   plugins: [],
 });


### PR DESCRIPTION
## 연관 이슈
- #168 

## 작업 요약
tailwindcss custom 색상으로 디자인에 쓰이는 색상 4가지 추가하였습니다
(흰색의 경우 white 색상과 동일하고, point 컬러에 투명도가 들어간 부분은 opacity로 조정할 수 있어서 별도로 커스텀에 넣지는 않았습니다.)
- `mainBlack`: #131316
- `middleBlack`: #18181C
- `subBlack`: #26262C
- `pointBlue`: #4CEEF9

<img width="80" alt="image" src="https://user-images.githubusercontent.com/78250089/215693648-142bb098-108f-4eda-8e46-76fbace375b9.png">

## 리뷰 요구사항
- `1분`, 색상 커스텀은 공식 문서에 있는대로 작업한거라 가볍게 보고 넘어가셔도 될 것 같습니다.