### PR TITLE
Feature/tailwindcss 기본 폰트 지정 #168

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@300;400;500&display=swap');
+
+@layer base {
+  html {
+    font-family: 'IBM Plex Sans KR', system-ui, sans-serif;
+  }
+}


### PR DESCRIPTION
## 연관 이슈
- #168

## 작업 요약
- default로 적용되는 폰트 지정

## 작업 상세 설명
- 디자인 회의때 지정한 `IBM Plex Sans KR` 폰트를 별도의 유틸리티 클래스를 작성하지 않아도 default로 적용되도록 하였습니다.
- `IBM Plex Sans KR` 대체 폰트로 tailwind 공식문서 예제와 동일하게 시스템 폰트와, (tailwindcss default 폰트인) sans 폰트도 같이 넣어주었습니다.
- 폰트 잘 적용되는 거 확인하였습니다.

## 리뷰 요구사항
`1분`, 가볍게 보고 넘어가셔도 될 것 같습니다.