### PR TITLE
Feature/tailwindcss 폰트 사이즈 커스텀 #168

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,12 @@ module.exports = withMT({
         subBlack: '#26262C',
         pointBlue: '#4CEEF9',
       },
+      fontSize: {
+        h1: '28pt',
+        h3: '20pt',
+        paragraph: '16pt',
+        small: '12pt',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 연관 이슈
- #168

## 작업 요약
tailwind config 파일 내 폰트 사이즈 커스텀 작성 

## 작업 상세 설명
h1: '28pt',
h3: '20pt',
paragraph: '16pt',
small: '12pt',
폰트 사이즈 추가

## 리뷰 요구사항
x

## Preview 이미지
