### PR TITLE
Feature/커스텀 색상 추가 #168

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,8 @@ module.exports = withMT({
         middleBlack: '#18181C',
         subBlack: '#26262C',
         pointBlue: '#4CEEF9',
+        subGray: '#575E69',
+        subRed: '#EF4444',
       },
     },
   },


### PR DESCRIPTION
## 연관 이슈
#168

## 작업 요약
보조 색상으로 사용되는 회색, 빨간 색 색상을 추가해주었음

## 작업 상세 설명
사용 예시 ) `text-subGray` `border-subRed`

## 리뷰 요구사항
1분!

## Preview 이미지
![image](https://user-images.githubusercontent.com/81465068/216808072-69a20792-4d3d-42cc-886a-45173dd73f95.png)
이미지에 붉은 원으로 표시한 두 가지 색상을 추가함.
