### PR TITLE
Feature/레이아웃 구성 #102

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import useMainRouter from '@router/useMainRouter';
 const App = () => {
   const routes = useMainRouter();
 
-  return <div className="App">{routes}</div>;
+  return <div className="bg-subBlack">{routes}</div>;
 };
 
 export default App;

--- a/src/components/Layout/Container/FitContainer.tsx
+++ b/src/components/Layout/Container/FitContainer.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const FitContainer = () => {
+  return (
+    <div className="flex w-full justify-center pt-header">
+      <div className="w-full max-w-container">
+        <Outlet />
+      </div>
+    </div>
+  );
+};
+
+export default FitContainer;

--- a/src/components/Layout/Container/FullContainer.tsx
+++ b/src/components/Layout/Container/FullContainer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const FullContainer = () => {
+  return (
+    <div className="pt-header">
+      <Outlet />
+    </div>
+  );
+};
+
+export default FullContainer;

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Header = () => {
+  return <div className="fixed h-header w-full border-b border-pointBlue bg-mainBlack" />;
+};
+
+export default Header;

--- a/src/components/Layout/Header/index.ts
+++ b/src/components/Layout/Header/index.ts
@@ -1,0 +1,3 @@
+import Header from './Header';
+
+export default Header;

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+import Header from './Header';
+import Sidebar from './Sidebar';
+
+const MainLayout = () => {
+  return (
+    <div className="flex">
+      <Header />
+      <Sidebar />
+      <Outlet />
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Sidebar = () => {
-  return <div className="flex h-screen w-sidebar bg-mainBlack pt-header" />;
+  return <div className="flex h-screen w-sidebar min-w-sidebar bg-mainBlack pt-header" />;
 };
 
 export default Sidebar;

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Sidebar = () => {
+  return <div className="flex h-screen w-sidebar bg-mainBlack pt-header" />;
+};
+
+export default Sidebar;

--- a/src/components/Layout/Sidebar/index.ts
+++ b/src/components/Layout/Sidebar/index.ts
@@ -1,0 +1,3 @@
+import Sidebar from './Sidebar';
+
+export default Sidebar;

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { useRoutes } from 'react-router-dom';
 import Home from '@pages/home/Home';
 import SeminarManage from '@pages/admin/SeminarManage';
+import MainLayout from '@components/Layout/MainLayout';
 
 const useMainRouter = () =>
   useRoutes([
     {
       path: '/',
+      element: <MainLayout />,
       children: [
         {
           index: true,

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -3,6 +3,8 @@ import { useRoutes } from 'react-router-dom';
 import Home from '@pages/home/Home';
 import SeminarManage from '@pages/admin/SeminarManage';
 import MainLayout from '@components/Layout/MainLayout';
+import FullContainer from '@components/Layout/Container/FullContainer';
+import FitContainer from '@components/Layout/Container/FitContainer';
 
 const useMainRouter = () =>
   useRoutes([
@@ -11,15 +13,25 @@ const useMainRouter = () =>
       element: <MainLayout />,
       children: [
         {
-          index: true,
-          element: <Home />,
-        },
-        {
-          path: 'admin',
+          element: <FullContainer />,
           children: [
             {
-              path: 'seminarManage',
-              element: <SeminarManage />,
+              index: true,
+              element: <Home />,
+            },
+          ],
+        },
+        {
+          element: <FitContainer />,
+          children: [
+            {
+              path: 'admin',
+              children: [
+                {
+                  path: 'seminarManage',
+                  element: <SeminarManage />,
+                },
+              ],
             },
           ],
         },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,9 @@ module.exports = withMT({
       maxWidth: {
         container: '1080px',
       },
+      minWidth: {
+        sidebar: '320px',
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,10 @@ module.exports = withMT({
         subBlack: '#26262C',
         pointBlue: '#4CEEF9',
       },
+      spacing: {
+        header: '66px',
+        sidebar: '320px',
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = withMT({
         header: '66px',
         sidebar: '320px',
       },
+      maxWidth: {
+        container: '1080px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 연관 이슈
- Close #102 

## 작업 요약
- 레이아웃 구성 및 css를 적용함.

## 작업 상세 설명
- router 상위에 레이아웃 배치하여, 하위 라우터들을 레이아웃으로 감싸지도록 구현
- 헤더와 사이드바로 구성된 레이아웃과 내부 contents들이 들어가는 컨테이너로 구분하여 구현
- 컨테이너의 경우 메인 페이지와 같이 전체 영역을 쓰는 부분과 게시글 등의 한정된 영역(1080px)에 쓰이는 부분이 나눠짐에 따라 2가지로 구분함.

## 리뷰 요구사항
- 7분
- 상수 부분 따로 빼려고 `tailwind.config.js` 파일에 커스텀하여 사이즈 지정해주었는데 `spacing`만으로 모든 사이즈 지정할 수 없고, `min/max width`의 경우 별도로 커스텀 사이즈 만들어야 돼서 `sidebar`가 두번이나 들어가게 되었네요.. 이대로 가도 괜찮을까요? 아니면 다른 좋은 방법이 있을까요?
  ```js
  spacing: {
    header: '66px',
    sidebar: '320px',
  },
  maxWidth: {
    container: '1080px',
  },
  minWidth: {
    sidebar: '320px',
  },
  ```

## Preview 이미지
<img width="500" alt="image" src="https://user-images.githubusercontent.com/78250089/216847461-ff4d0bd0-fabd-4b00-98e5-53f42095adec.png"> <img width="500" alt="image" src="https://user-images.githubusercontent.com/78250089/216847507-2cce8ad7-16b0-4c56-99ae-ad8e279f53d2.png">

