### PR TITLE
Feature/공통 테이블 다크모드 디자인 적용 #130

### DIFF
--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -14,7 +14,7 @@ const StandardTable = <T extends Record<string, any>>({ columns, rows }: Standar
       <TableHead className="bg-middleBlack">
         <TableRow>
           {columns.map((column) => (
-            <TableCell className="!border-subBlack" key={column.key as string}>
+            <TableCell className="!border-subBlack !text-white" key={column.key as string}>
               {column.headerName}
             </TableCell>
           ))}
@@ -25,7 +25,7 @@ const StandardTable = <T extends Record<string, any>>({ columns, rows }: Standar
           <TableRow>
             {columns.map((column) => {
               return (
-                <TableCell className="!border-subBlack bg-mainBlack" key={column.key as string}>
+                <TableCell className="!border-subBlack bg-mainBlack !text-white" key={column.key as string}>
                   {row[column.key]}
                 </TableCell>
               );

--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -14,7 +14,9 @@ const StandardTable = <T extends Record<string, any>>({ columns, rows }: Standar
       <TableHead className="bg-middleBlack">
         <TableRow>
           {columns.map((column) => (
-            <TableCell key={column.key as string}>{column.headerName}</TableCell>
+            <TableCell className="!border-subBlack" key={column.key as string}>
+              {column.headerName}
+            </TableCell>
           ))}
         </TableRow>
       </TableHead>
@@ -23,7 +25,7 @@ const StandardTable = <T extends Record<string, any>>({ columns, rows }: Standar
           <TableRow>
             {columns.map((column) => {
               return (
-                <TableCell className="bg-mainBlack" key={column.key as string}>
+                <TableCell className="!border-subBlack bg-mainBlack" key={column.key as string}>
                   {row[column.key]}
                 </TableCell>
               );

--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -11,7 +11,7 @@ interface StandardTableProps<T extends Record<string, any>> {
 const StandardTable = <T extends Record<string, any>>({ columns, rows }: StandardTableProps<T>) => {
   return (
     <Table>
-      <TableHead>
+      <TableHead className="bg-middleBlack">
         <TableRow>
           {columns.map((column) => (
             <TableCell key={column.key as string}>{column.headerName}</TableCell>
@@ -22,7 +22,11 @@ const StandardTable = <T extends Record<string, any>>({ columns, rows }: Standar
         {rows.map((row) => (
           <TableRow>
             {columns.map((column) => {
-              return <TableCell key={column.key as string}>{row[column.key]}</TableCell>;
+              return (
+                <TableCell className="bg-mainBlack" key={column.key as string}>
+                  {row[column.key]}
+                </TableCell>
+              );
             })}
           </TableRow>
         ))}


### PR DESCRIPTION
## 연관 이슈
- #130

## 작업 요약
공통 테이블 다크모드 디자인에 맞게 색상 적용하였습니다.

## 작업 상세 설명
- 테이블 배경색 적용
- row 구분선 색 적용
- 텍스트 색 적용

## 리뷰 요구사항
- 1분
- MUI 컴포넌트인데도 tailwindcss 적용이 되더라구요...! 다만 MUI 내부 css와 충돌되어 적용이 안되는 부분들은 important 처리해주었습니다! 별도로 커스텀할 수 있는 방법이 있긴한데 tailwind로 넣는게 확실히 깔끔하긴 하더라구요! 이렇게 처리해도 괜찮을 지 한 번 봐주세요!

## Preview 이미지
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/78250089/217547889-aa76347e-fbdb-4714-907b-6da3421fa4b8.png">

