### PR TITLE
Feature/컨테이너 상단 간격 추가 #194

### DIFF
--- a/src/components/Layout/Container/FitContainer.tsx
+++ b/src/components/Layout/Container/FitContainer.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const FitContainer = () => {
   return (
-    <div className="mt-header flex w-full justify-center">
+    <div className="mt-header flex w-full justify-center pt-16">
       <div className="w-full max-w-container">
         <Outlet />
       </div>

--- a/src/components/Layout/Container/FitContainer.tsx
+++ b/src/components/Layout/Container/FitContainer.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const FitContainer = () => {
   return (
-    <div className="flex w-full justify-center pt-header">
+    <div className="mt-header flex w-full justify-center">
       <div className="w-full max-w-container">
         <Outlet />
       </div>

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Sidebar = () => {
-  return <div className="flex h-screen w-sidebar min-w-sidebar bg-mainBlack pt-header" />;
+  return <div className="mt-header flex h-screen w-sidebar min-w-sidebar bg-mainBlack" />;
 };
 
 export default Sidebar;


### PR DESCRIPTION
## 연관 이슈
- #194 

## 작업 요약
- 헤더와 페이지 제목 사이 간격 컨테이너에 추가

## 작업 상세 설명
- 헤더가 차지하는 공간 padding으로 넣어두었었는데 공간 컨테이너 외부 영역으로 인식되게 하기 위해 margin으로 변경해주었습니다.
- 컨테이너에서 헤더와 페이지 제목 사이 간격을 padding으로 추가해주었습니다.

## 리뷰 요구사항
2분, 주의깊게 봐야할 부분은 딱히 없습니다!

## Preview 이미지
<img width="1218" alt="image" src="https://user-images.githubusercontent.com/78250089/217792709-106ac5ea-6bd4-47e8-9396-d6bb6ba51c93.png">
