### PR TITLE
Feature/material tailwind input 커스텀 #174

### DIFF
--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -1,7 +1,8 @@
-import type { TypographyStylesType } from '@material-tailwind/react';
+import type { TypographyStylesType, InputStylesType } from '@material-tailwind/react';
 
 interface CustomTheme {
   typography: TypographyStylesType;
+  input: InputStylesType;
 }
 
 const theme: CustomTheme = {
@@ -21,6 +22,11 @@ const theme: CustomTheme = {
           fontSize: 'text-[10px]',
         },
       },
+    },
+  },
+  input: {
+    defaultProps: {
+      variant: 'standard',
     },
   },
 };

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -28,6 +28,13 @@ const theme: CustomTheme = {
     defaultProps: {
       variant: 'standard',
     },
+    styles: {
+      base: {
+        container: {
+          width: 'min-w-min',
+        },
+      },
+    },
   },
 };
 

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -34,7 +34,8 @@ const theme: CustomTheme = {
           width: 'min-w-min',
         },
         input: {
-          border: '!border-pointBlue',
+          border: '!border-pointBlue disabled:border-b disabled:!border-opacity-50',
+          background: 'disabled:!bg-transparent',
         },
         label: {
           border: 'after:border-pointBlue peer-focus:after:border-pointBlue',

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -35,6 +35,7 @@ const theme: CustomTheme = {
         },
         input: {
           border: '!border-pointBlue disabled:border-b disabled:!border-opacity-50',
+          color: 'text-white',
           background: 'disabled:!bg-transparent',
         },
         label: {

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -31,7 +31,7 @@ const theme: CustomTheme = {
     styles: {
       base: {
         container: {
-          width: 'min-w-min',
+          width: 'min-w-min w-fit',
         },
         input: {
           border: '!border-pointBlue disabled:border-b disabled:!border-opacity-50',

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -40,6 +40,7 @@ const theme: CustomTheme = {
         },
         label: {
           border: 'after:border-pointBlue peer-focus:after:border-pointBlue',
+          color: ' peer-focus:text-pointBlue',
         },
       },
     },

--- a/src/constants/materialTailwindTheme.ts
+++ b/src/constants/materialTailwindTheme.ts
@@ -33,6 +33,12 @@ const theme: CustomTheme = {
         container: {
           width: 'min-w-min',
         },
+        input: {
+          border: '!border-pointBlue',
+        },
+        label: {
+          border: 'after:border-pointBlue peer-focus:after:border-pointBlue',
+        },
       },
     },
   },


### PR DESCRIPTION
## 연관 이슈
- #174

## 작업 요약
- material tailwind `Input` 컴포넌트 디자인 커스텀

## 작업 상세 설명
- 기본형태 (standard) 지정
- 색 지정

## 리뷰 요구사항
- 3분

## Preview 이미지
<img width="173" alt="image" src="https://user-images.githubusercontent.com/78250089/218693135-8cf821b6-2d40-4c6f-9333-e6954491ede3.png"> <img width="175" alt="image" src="https://user-images.githubusercontent.com/78250089/218693038-cd255768-fce6-4908-be6b-034ae83c8a9a.png">

### Preview 예제 코드
```tsx
import React from 'react';
import { Input } from '@material-tailwind/react';

const Example = () => {
  return (
    <Input label="아아" className="w-32" />
  );
};
```
- 기본 디자인 입혀져 있는 상태이기 때문에 사용할 때 넓이 조정 제외하고는 크게 css 처리 안 해줘도 될 겁니다!