### PR TITLE
Feature/모달 열림 여부 props로 전달하도록 확장 #217

### DIFF
--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Button, Dialog, DialogHeader, DialogBody, DialogFooter } from '@material-tailwind/react';
 
@@ -8,10 +8,10 @@ interface ActionModalProps {
   title: string;
   children: React.ReactNode;
   buttonName: string;
-  onClick: () => void;
+  onActionButonClick: () => void;
 }
 
-const ActionModal = ({ opened, handleOpen, title, children, buttonName, onClick }: ActionModalProps) => {
+const ActionModal = ({ opened, handleOpen, title, children, buttonName, onActionButonClick }: ActionModalProps) => {
   return (
     <Dialog open={opened} handler={handleOpen} className="rounded-lg bg-[#26262c]">
       <div className="mt-7 ml-10 mb-2 mr-2">
@@ -27,10 +27,7 @@ const ActionModal = ({ opened, handleOpen, title, children, buttonName, onClick 
           </Button>
           <Button
             variant="outlined"
-            onClick={() => {
-              onClick();
-              handleOpen();
-            }}
+            onClick={onActionButonClick}
             className="flex-shrink-0 flex-grow-0 rounded-sm border-none bg-[#4ceef9] text-center text-xs font-semibold text-[#26262c]"
           >
             {buttonName}

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -3,16 +3,15 @@ import React, { useState } from 'react';
 import { Button, Dialog, DialogHeader, DialogBody, DialogFooter } from '@material-tailwind/react';
 
 interface ActionModalProps {
+  open: boolean;
+  handleOpen: () => void;
   title: string;
   children: React.ReactNode;
   buttonName: string;
   onClick: () => void;
 }
 
-const ActionModal = ({ title, children, buttonName, onClick }: ActionModalProps) => {
-  const [open, setOpen] = useState(true);
-  const handleOpen = () => setOpen(!open);
-
+const ActionModal = ({ open, handleOpen, title, children, buttonName, onClick }: ActionModalProps) => {
   return (
     <Dialog open={open} handler={handleOpen} className="rounded-lg bg-[#26262c]">
       <div className="mt-7 ml-10 mb-2 mr-2">
@@ -28,7 +27,10 @@ const ActionModal = ({ title, children, buttonName, onClick }: ActionModalProps)
           </Button>
           <Button
             variant="outlined"
-            onClick={onClick}
+            onClick={() => {
+              onClick();
+              handleOpen();
+            }}
             className="flex-shrink-0 flex-grow-0 rounded-sm border-none bg-[#4ceef9] text-center text-xs font-semibold text-[#26262c]"
           >
             {buttonName}

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Button, Dialog, DialogHeader, DialogBody, DialogFooter } from '@material-tailwind/react';
 
 interface ActionModalProps {
-  open: boolean;
+  opened: boolean;
   handleOpen: () => void;
   title: string;
   children: React.ReactNode;
@@ -11,9 +11,9 @@ interface ActionModalProps {
   onClick: () => void;
 }
 
-const ActionModal = ({ open, handleOpen, title, children, buttonName, onClick }: ActionModalProps) => {
+const ActionModal = ({ opened, handleOpen, title, children, buttonName, onClick }: ActionModalProps) => {
   return (
-    <Dialog open={open} handler={handleOpen} className="rounded-lg bg-[#26262c]">
+    <Dialog open={opened} handler={handleOpen} className="rounded-lg bg-[#26262c]">
       <div className="mt-7 ml-10 mb-2 mr-2">
         <DialogHeader className="text-left font-bold text-[#4ceef9]">{title}</DialogHeader>
         <DialogBody className="text-left text-base text-white">{children}</DialogBody>


### PR DESCRIPTION
## 연관 이슈
- #217 #131 

## 예제코드 
모달창 사용하는 컴포넌트에서 추가하면 됩니다.

``` tsx
const [open, toggleOpen] = useReducer((prev) => !prev, false);

  return (
    <div>
      <FilledButton onClick={toggleOpen}>도서 추가</FilledButton>

      <ActionModal
        opened={open}
        handleOpen={toggleOpen}
        title="도서추가"
        buttonName="추가"
        onActionButonClick={toggleOpen}
      >
        컨텐츠입니다
      </ActionModal>
    </div>
  );
```
  
## 작업 요약
- 기존에는 모달창 컴포넌트안에서 열림여부 state를 관리했는데, 이를 모달창 사용하는 외부에서 관리하도록 수정
- 확인버튼을 누를때 props로 넘겨준 함수(기존) +모달창 닫기함수 추가.

## 작업 상세 설명
- 모달창 컴포넌트 내부
![image](https://user-images.githubusercontent.com/81643702/218971261-ade84647-30c1-4021-8bb0-65696e5d17e5.png)
내부에서 관리하던 state삭제, 외부로 옮김
![image](https://user-images.githubusercontent.com/81643702/218971369-56decf4e-9f96-4693-b9d0-a45608c5facc.png)
모달창 닫기함수 추가

## 리뷰 요구사항
- 3분
- 모달창 쓰고싶습니다! 리뷰 부탁드립니다!
