### PR TITLE
Feature/버튼 상위 태그에 따라 높이 변경되지 않도록 처리 #241

### DIFF
--- a/src/components/Button/FilledButton.tsx
+++ b/src/components/Button/FilledButton.tsx
@@ -11,7 +11,7 @@ const FilledButton = ({ children, onClick, disabled }: OutlinedButtonProps) => {
   return (
     <Button
       variant="filled"
-      className="rounded-sm bg-pointBlue py-2 font-base text-subBlack hover:opacity-80 hover:shadow-none"
+      className="h-fit rounded-sm bg-pointBlue py-2 font-base text-subBlack hover:opacity-80 hover:shadow-none"
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/Button/OutlinedButton.tsx
+++ b/src/components/Button/OutlinedButton.tsx
@@ -11,7 +11,7 @@ const OutlinedButton = ({ children, onClick, disabled }: OutlinedButtonProps) =>
   return (
     <Button
       variant="outlined"
-      className="rounded-sm border-pointBlue py-2 font-base text-pointBlue focus:ring-0"
+      className="h-fit rounded-sm border-pointBlue py-2 font-base text-pointBlue focus:ring-0"
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -11,7 +11,7 @@ const TextButton = ({ children, onClick, disabled }: TextButtonProps) => {
   return (
     <Button
       variant="text"
-      className="rounded-sm py-2 font-base text-pointBlue hover:bg-pointBlue/10 active:bg-pointBlue/30"
+      className="h-fit rounded-sm py-2 font-base text-pointBlue hover:bg-pointBlue/10 active:bg-pointBlue/30"
       onClick={onClick}
       disabled={disabled}
     >


### PR DESCRIPTION
## 연관 이슈
- Close #241

## 작업 요약
- flex 적용된 상위 컴포넌트 높이 따라가지 않도록 내부 요소에 따는 높이 지정

## 작업 상세 설명
- content 기반으로 높이 지정해주었습니다.

## 리뷰 요구사항
- 0.5분, 변경 사항 간단합니다!