### PR TITLE
Feature/기본 텍스트 컬러 흰색 지정 #243

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -7,5 +7,6 @@
 @layer base {
   html {
     font-family: 'IBM Plex Sans KR', system-ui, sans-serif;
+    color: #fff;
   }
 }


### PR DESCRIPTION
## 연관 이슈
- Close #243

## 작업 요약
-  다크모드를 기본 테마로 하고 있기 때문에 기존 base 컬러인 검은색 대신 흰색이 기본으로 사용되도록 변경

## 리뷰 요구사항
- 0.2분
- tailwind.css 파일에 텍스트 색만 추가하였습니다. 별도의 색 지정 없이 텍스트 흰색으로 잘 나오는 거 확인하였습니다.
