### PR TITLE
Feature/mui 커스텀 컬러 설정 #247

### DIFF
--- a/src/components/Pagination/StandardTablePagination.tsx
+++ b/src/components/Pagination/StandardTablePagination.tsx
@@ -37,7 +37,7 @@ const StandardTablePagination = ({ rowsPerPage = 10 }: StandardTablePaginationPr
         labelDisplayedRows={({ from, to, count }) => `Showing ${from}-${to} of ${count} items`}
       />
       <Pagination
-        color="primary"
+        color="secondary"
         className="mr-1 !text-pointBlue"
         count={totalPages}
         shape="rounded"

--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -4,6 +4,9 @@ const muiTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
+      main: '#4CEEF9',
+    },
+    secondary: {
       main: '#26262C',
       contrastText: '#4CEEF9',
     },


### PR DESCRIPTION
## 연관 이슈
- Close #247

## 작업 요약
- mui custom color 지정

## 작업 상세 설명
- 색상들이 헥스코드로 되어 있는 상태인데, tailwindcss 커스텀과 별개로 지정하기 보다는 contants 폴더에 상수로 지정해두고 mui와 tailwindcss에 한 번에 지정해주면 좋을 것 같아서 따로 이슈 생성해서 진행할 예정입니다.
- `primary`는 input, select, datepicker 등에 사용되는 default 색상으로 보면 되고, `secondary`는 pagination 등에 사용되는 색상 배치라고 보면 됩니다. 어떻게 더 확장될 지는 아직 잘 파악이 안돼서 일단 이정도로 작업해두었습니다.
- 기존에 pagination 처리하면서 pagination 색상 배치를 `primary`로 하였는데 input등에 사용되는 컬러가 더 빈번하게 쓰일 것 같아서 pagination color를 `secondary`로 내려주었습니다.

## 리뷰 요구사항
- 1분, 커스텀 하는데 있어서 더 좋은 의견있으면 남겨주세요~!