### PR TITLE
Feature/ActionModal MUI 컴포넌트 사용으로 변경 #287

### DIFF
--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Dialog, DialogHeader, DialogBody, DialogFooter, Typography } from '@material-tailwind/react';
+import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { Typography } from '@material-tailwind/react';
 import FilledButton from '@components/Button/FilledButton';
 import TextButton from '@components/Button/TextButton';
 
@@ -14,18 +15,18 @@ interface ActionModalProps {
 
 const ActionModal = ({ opened, handleOpen, title, children, buttonName, onActionButonClick }: ActionModalProps) => {
   return (
-    <Dialog open={opened} handler={handleOpen} className="rounded-lg bg-subBlack">
+    <Dialog open={opened} className="rounded-lg bg-subBlack">
       <div className="mt-5 ml-10 mb-2 mr-10">
-        <DialogHeader className="break-all text-pointBlue">
+        <DialogTitle component="div" className="break-all text-pointBlue">
           <Typography variant="h3">{title}</Typography>
-        </DialogHeader>
-        <DialogBody className="mb-20 break-all text-white">
+        </DialogTitle>
+        <DialogContent className="mb-20 break-all text-white">
           <Typography variant="paragraph">{children}</Typography>
-        </DialogBody>
-        <DialogFooter className="absolute right-1 bottom-1">
+        </DialogContent>
+        <DialogActions className="absolute right-1 bottom-1">
           <TextButton onClick={handleOpen}>취소</TextButton>
           <FilledButton onClick={onActionButonClick}>{buttonName}</FilledButton>
-        </DialogFooter>
+        </DialogActions>
       </div>
     </Dialog>
   );

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -4,7 +4,7 @@ import FilledButton from '@components/Button/FilledButton';
 import TextButton from '@components/Button/TextButton';
 
 interface ActionModalProps {
-  opened: boolean;
+  open: boolean;
   onClose: () => void;
   modalWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   title: string;
@@ -14,7 +14,7 @@ interface ActionModalProps {
 }
 
 const ActionModal = ({
-  opened,
+  open,
   onClose,
   modalWidth,
   title,
@@ -23,7 +23,7 @@ const ActionModal = ({
   onActionButonClick,
 }: ActionModalProps) => {
   return (
-    <Dialog open={opened} PaperProps={{ className: 'px-2 py-1' }} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
+    <Dialog open={open} PaperProps={{ className: 'px-2 py-1' }} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
       <DialogTitle className="!font-bold text-pointBlue">{title}</DialogTitle>
       <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -16,7 +16,7 @@ const ActionModal = ({ opened, onClose, title, children, actionButtonName, onAct
   return (
     <Dialog open={opened}>
       <DialogTitle className="text-pointBlue">{title}</DialogTitle>
-      <DialogContent>{children}</DialogContent>
+      <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>
         <TextButton onClick={onClose}>취소</TextButton>
         <FilledButton onClick={onActionButonClick}>{actionButtonName}</FilledButton>

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -6,15 +6,24 @@ import TextButton from '@components/Button/TextButton';
 interface ActionModalProps {
   opened: boolean;
   onClose: () => void;
+  modalWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   title: string;
   children: React.ReactNode;
   actionButtonName: string;
   onActionButonClick: () => void;
 }
 
-const ActionModal = ({ opened, onClose, title, children, actionButtonName, onActionButonClick }: ActionModalProps) => {
+const ActionModal = ({
+  opened,
+  onClose,
+  modalWidth,
+  title,
+  children,
+  actionButtonName,
+  onActionButonClick,
+}: ActionModalProps) => {
   return (
-    <Dialog open={opened}>
+    <Dialog open={opened} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
       <DialogTitle className="text-pointBlue">{title}</DialogTitle>
       <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -20,9 +20,7 @@ const ActionModal = ({ opened, handleOpen, title, children, buttonName, onAction
         <DialogTitle component="div" className="break-all text-pointBlue">
           <Typography variant="h3">{title}</Typography>
         </DialogTitle>
-        <DialogContent className="mb-20 break-all text-white">
-          <Typography variant="paragraph">{children}</Typography>
-        </DialogContent>
+        <DialogContent className="mb-20 break-all text-white">{children}</DialogContent>
         <DialogActions className="absolute right-1 bottom-1">
           <TextButton onClick={handleOpen}>취소</TextButton>
           <FilledButton onClick={onActionButonClick}>{buttonName}</FilledButton>

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
-import { Typography } from '@material-tailwind/react';
 import FilledButton from '@components/Button/FilledButton';
 import TextButton from '@components/Button/TextButton';
 
@@ -15,17 +14,13 @@ interface ActionModalProps {
 
 const ActionModal = ({ opened, handleOpen, title, children, buttonName, onActionButonClick }: ActionModalProps) => {
   return (
-    <Dialog open={opened} className="rounded-lg bg-subBlack">
-      <div className="mt-5 ml-10 mb-2 mr-10">
-        <DialogTitle component="div" className="break-all text-pointBlue">
-          <Typography variant="h3">{title}</Typography>
-        </DialogTitle>
-        <DialogContent className="mb-20 break-all text-white">{children}</DialogContent>
-        <DialogActions className="absolute right-1 bottom-1">
-          <TextButton onClick={handleOpen}>취소</TextButton>
-          <FilledButton onClick={onActionButonClick}>{buttonName}</FilledButton>
-        </DialogActions>
-      </div>
+    <Dialog open={opened}>
+      <DialogTitle className="text-pointBlue">{title}</DialogTitle>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions>
+        <TextButton onClick={handleOpen}>취소</TextButton>
+        <FilledButton onClick={onActionButonClick}>{buttonName}</FilledButton>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -5,21 +5,21 @@ import TextButton from '@components/Button/TextButton';
 
 interface ActionModalProps {
   opened: boolean;
-  handleOpen: () => void;
+  onClose: () => void;
   title: string;
   children: React.ReactNode;
-  buttonName: string;
+  actionButtonName: string;
   onActionButonClick: () => void;
 }
 
-const ActionModal = ({ opened, handleOpen, title, children, buttonName, onActionButonClick }: ActionModalProps) => {
+const ActionModal = ({ opened, onClose, title, children, actionButtonName, onActionButonClick }: ActionModalProps) => {
   return (
     <Dialog open={opened}>
       <DialogTitle className="text-pointBlue">{title}</DialogTitle>
       <DialogContent>{children}</DialogContent>
       <DialogActions>
-        <TextButton onClick={handleOpen}>취소</TextButton>
-        <FilledButton onClick={onActionButonClick}>{buttonName}</FilledButton>
+        <TextButton onClick={onClose}>취소</TextButton>
+        <FilledButton onClick={onActionButonClick}>{actionButtonName}</FilledButton>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -23,7 +23,7 @@ const ActionModal = ({
   onActionButonClick,
 }: ActionModalProps) => {
   return (
-    <Dialog open={opened} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
+    <Dialog open={opened} PaperProps={{ className: 'px-2 py-1' }} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
       <DialogTitle className="text-pointBlue">{title}</DialogTitle>
       <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -24,7 +24,7 @@ const ActionModal = ({
 }: ActionModalProps) => {
   return (
     <Dialog open={opened} PaperProps={{ className: 'px-2 py-1' }} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
-      <DialogTitle className="text-pointBlue">{title}</DialogTitle>
+      <DialogTitle className="!font-bold text-pointBlue">{title}</DialogTitle>
       <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>
         <TextButton onClick={onClose}>취소</TextButton>

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -20,9 +20,9 @@ const StudyModal = ({ open, isModify, handleOpen, studyId }: StudyModalProps): J
   return (
     <ActionModal
       opened={open}
-      handleOpen={handleOpen}
+      onClose={handleOpen}
       title={isModify ? '스터디 수정' : '스터디 생성'}
-      buttonName={isModify ? '적용하기' : '생성하기'}
+      actionButtonName={isModify ? '적용하기' : '생성하기'}
       onActionButonClick={handleOpen}
     >
       <div className="space-y-6">

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -19,7 +19,7 @@ const memberList = ['김은지', '장서윤', '송세연'];
 const StudyModal = ({ open, isModify, handleOpen, studyId }: StudyModalProps): JSX.Element => {
   return (
     <ActionModal
-      opened={open}
+      open={open}
       onClose={handleOpen}
       title={isModify ? '스터디 수정' : '스터디 생성'}
       actionButtonName={isModify ? '적용하기' : '생성하기'}


### PR DESCRIPTION
## 연관 이슈
- #286 #287 

## 작업 요약
- 모달 Material tailwind -> Mui 라이브러리 사용하는 걸로 변경

## 작업 상세 설명
- mui Dialog 사용하는 걸로 변경하면서 스타일 적용한 부분 해당 라이브러리에 맞춰 새로 적용 및 일부 리팩토링도 같이 해주었습니다.
- width 지정을 통일성있게 가면 좋을 것 같아서 mui에서 제공하는 maxWidth를 각 넓이에 대해 바로 설정해줄 수 있도록 처리해주었습니다.

## 리뷰 요구사항
- @pipisebastian  Dialog 전체적인 padding 같은 경우 디자인 된 사항과 조금 상이한데 라이브러리 자체 기본 padding 쓰는 것도 괜찮을 것 같아서 디자인 쪽 한 번 체크 부탁드립니다!
- 코멘트로 추가 리뷰 요구사항 달아두겠습니다!

## Preview 이미지
넓이 지정 안되어 있는 기본 크기 모달입니다.
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/78250089/223367667-c389195e-a42a-423f-918a-c40c365e2ff3.png">

넓이를 xs 사이즈로 지정해둔 모달입니다. 아래 예제 코드 참고해주세요.
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/78250089/223368500-1991e6ac-2b78-4338-8c0d-4c961f3a2a0f.png">

### Preview 예제 코드
```tsx
const Example = () => {
  const [libraryAddModalopen, setLibraryAddModalopen] = useState(false);

  return (
    <div>
      <OutlinedButton onClick={() => setLibraryAddModalopen(true)}>추가</OutlinedButton>
      <ActionModal
        modalWidth="xs"
        open={libraryAddModalopen}
        onClose={() => setLibraryAddModalopen(false)}
        title="도서추가"
        actionButtonName="추가"
        onActionButonClick={() => {
          console.log('');
        }}
      >
        안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~안녕하세요~
      </ActionModal>
    </div>
  );
};
```

참고) material tailwind에서의 handler가 필수값이 아니게 된 만큼 modal의 열고 닫는 기능이 명확하게 나타나는 게 좋을 것 같아서 이전에 제안했던 `useReducer` 사용하여 구현하는 방식이 아닌 `setState`사용하여 true, false로 완전히 지정해주는 방식으로 예제 작성해보았습니다.
