### PR TITLE
Feature/MUI 폰트 적용

### DIFF
--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -11,6 +11,9 @@ const muiTheme = createTheme({
       contrastText: '#4CEEF9',
     },
   },
+  typography: {
+    fontFamily: ['IBM Plex Sans KR', 'system-ui', 'sans-serif'].join(','),
+  },
 });
 
 export default muiTheme;


### PR DESCRIPTION
## 연관 이슈
- Close #304

## 작업 요약
- 프로젝트 폰트로 정한 `IBM Plex Sans KR` 폰트 MUI에 적용되도록 구현하였습니다.

## 작업 상세 설명
- typography에 폰트 지정해주었고, `Typography`, `Table` 컴포넌트에서 폰트 적용되는 것 확인하였습니다.

## 리뷰 요구사항
- 0.1분
- MUI 컴포넌트인데 폰트 적용 안 되는 부분 있으면 알려주세요!
