### PR TITLE
Feature/회원가입 진행 카드 레이아웃 UI 생성 #292

### DIFF
--- a/src/components/Progress/StepProgress.tsx
+++ b/src/components/Progress/StepProgress.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { LinearProgress } from '@mui/material';
 
 interface StepProgress {
+  className?: string;
   currentStep: number;
   totalStep: number;
 }
 
-const StepProgress = ({ currentStep, totalStep }: StepProgress) => {
+const StepProgress = ({ className, currentStep, totalStep }: StepProgress) => {
   const currentProgressRate = (100 / totalStep) * currentStep;
 
-  return <LinearProgress className="w-32" variant="determinate" value={currentProgressRate} />;
+  return <LinearProgress className={className} variant="determinate" value={currentProgressRate} />;
 };
 
 export default StepProgress;

--- a/src/components/Progress/StepProgress.tsx
+++ b/src/components/Progress/StepProgress.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { LinearProgress } from '@mui/material';
+
+interface StepProgress {
+  currentStep: number;
+  totalStep: number;
+}
+
+const StepProgress = ({ currentStep, totalStep }: StepProgress) => {
+  const currentProgressRate = (100 / totalStep) * currentStep;
+
+  return <LinearProgress className="w-32" variant="determinate" value={currentProgressRate} />;
+};
+
+export default StepProgress;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SignUp = () => {
+  return <div />;
+};
+
+export default SignUp;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
+import { Box } from '@mui/material';
 
 const SignUp = () => {
   return (
-    <div className="grid h-screen place-content-center">
-      <Logo className="w-48" />
+    <div className="grid h-screen place-content-center place-items-center">
+      <Logo className="mb-9 w-48" />
+      <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14" />
     </div>
   );
 };

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
+import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
+
 const SignUp = () => {
-  return <div />;
+  return (
+    <div className="grid h-screen place-content-center">
+      <Logo className="w-48" />
+    </div>
+  );
 };
 
 export default SignUp;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -2,12 +2,19 @@ import React from 'react';
 
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { Box } from '@mui/material';
+import StepProgress from '@components/Progress/StepProgress';
 
 const SignUp = () => {
+  const TOTAL_STEPS = 3;
+
+  const currentStep = 1; // TODO 추후 state로 관리
+
   return (
     <div className="grid h-screen place-content-center place-items-center">
       <Logo className="mb-9 w-48" />
-      <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14" />
+      <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14">
+        <StepProgress currentStep={currentStep} totalStep={TOTAL_STEPS} />
+      </Box>
     </div>
   );
 };

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -13,7 +13,7 @@ const SignUp = () => {
     <div className="grid h-screen place-content-center place-items-center">
       <Logo className="mb-9 w-48" />
       <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14">
-        <StepProgress currentStep={currentStep} totalStep={TOTAL_STEPS} />
+        <StepProgress className="w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
       </Box>
     </div>
   );

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
 
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import StepProgress from '@components/Progress/StepProgress';
 
 const SignUp = () => {
   const TOTAL_STEPS = 3;
 
   const currentStep = 1; // TODO 추후 state로 관리
+  const stepInfoMsg = {
+    1: '로그인에 사용할\n아이디와 비밀번호를 등록해 주세요.',
+    2: '프로필 정보를 등록해 주세요.',
+    3: '이메일 주소를 입력해주세요.\n입력한 이메일 주소로 인증 코드가 발송됩니다.',
+  };
 
   return (
     <div className="grid h-screen place-content-center place-items-center">
       <Logo className="mb-9 w-48" />
       <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14">
-        <StepProgress className="w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
+        <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
+        <Typography className="whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
       </Box>
     </div>
   );

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
-import { Box, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import StepProgress from '@components/Progress/StepProgress';
+import OutlinedButton from '@components/Button/OutlinedButton';
 
 const SignUp = () => {
   const TOTAL_STEPS = 3;
@@ -18,8 +19,13 @@ const SignUp = () => {
     <div className="grid h-screen place-content-center place-items-center">
       <Logo className="mb-9 w-48" />
       <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14">
-        <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
-        <Typography className="whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
+        <Stack className="relative h-full w-full">
+          <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
+          <Typography className="whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
+          <div className="absolute right-0 bottom-0">
+            <OutlinedButton>다음</OutlinedButton>
+          </div>
+        </Stack>
       </Box>
     </div>
   );

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -10,6 +10,7 @@ import MainLayout from '@components/Layout/MainLayout';
 import FullContainer from '@components/Layout/Container/FullContainer';
 import FitContainer from '@components/Layout/Container/FitContainer';
 import BoardList from '@pages/board/BoardList';
+import SignUp from '@pages/SignUp/SignUp';
 
 const useMainRouter = () =>
   useRoutes([
@@ -23,6 +24,10 @@ const useMainRouter = () =>
             {
               index: true,
               element: <Home />,
+            },
+            {
+              path: 'signUp',
+              element: <SignUp />,
             },
           ],
         },


### PR DESCRIPTION
## 연관 이슈
- Close #292

## 작업 요약
- 회원가입 진행 카드 레이아웃 UI 구현하였습니다.

## 작업 상세 설명
- 로고, 외곽 박스, 진행바, 단계 안내 문구, 버튼 UI 구성해주었습니다.
- 진행바의 경우 총 단계 수와, 현재 단계를 props로 넘겨주면 해당 단계에 맞는 진행율을 보여주도록 하는 공통 컴포넌트로 제작하였습니다.

## 리뷰 요구사항
- 7분
- #303 PR이 선행 PR 이라 먼저 리뷰 후 이 PR 리뷰 부탁드립니다.
- [feat : 회원가입 UI 로고 추가](https://github.com/KEEPER31337/Homepage-Front-R2/commit/c271b79d1c14bfed919f7a93da263cdb7e112e48) 이 커밋부터 봐주시면 됩니다.
- `currentStep` 변수에 `1`, `2`, `3` 바꿔가면 넣어보시면 각 단계별로 확인할 수 있습니다.
- 버튼의 3단계 텍스트는 현재 구현되어 있는 `다음`이 아닌 `완료`인데 이건 나중에 기능 추가할 때 처리하겠습니다.
- 중간의 인풋 들어가는 부분의 UI는 다른 PR로 분리해서 올릴 예정입니다.

## Preview 이미지
<img width="300" alt="image" src="https://user-images.githubusercontent.com/78250089/226159378-5d8d95ec-54eb-4ee7-84dd-9aca1be4cf41.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/78250089/226159393-e1d12eda-a96d-4cce-b512-b980c76e34f2.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/78250089/226159409-9c196c77-ba5b-466e-a8ba-42dae5c64c63.png">
