### PR TITLE
Feature/세미나 출석 카운트다운 구현 #308

### DIFF
--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import FilledButton from '@components/Button/FilledButton';
+import { DateTime } from 'luxon';
 import Countdown from '../Countdown/Countdown';
 import SeminarSelector from '../Selector/SeminarSelector';
 import SeminarInput from '../Input/SeminarInput';
@@ -8,9 +9,12 @@ const BossCardContent = () => {
   const [attendValue, setAttendValue] = useState<number>(5);
   const [lateAttendValue, setLateAttendValue] = useState<number>(5);
   const [seminarExist, setSeminarExist] = useState(false); // Todo: api 적용
-
+  const [startTime, setStartTime] = useState(DateTime.now());
+  const attendLimit = startTime.plus({ days: 0, hours: 0, minutes: 0, seconds: 5 }); // 임시:이후 api에서 가져옴
+  const lateLimit = attendLimit.plus({ days: 0, hours: 0, minutes: 0, seconds: 5 }); // 임시: 이후 api에서 가져옴
   const startSeminar = () => {
     setSeminarExist(true);
+    setStartTime(DateTime.now());
   };
 
   return (
@@ -24,9 +28,12 @@ const BossCardContent = () => {
           <div>출석</div>
           <div>지각</div>
         </div>
-        <div className="grid content-between">
+        <div className="grid content-between text-right">
           {seminarExist ? (
-            <Countdown />
+            <>
+              <Countdown startTime={startTime} endTime={attendLimit} />
+              <Countdown startTime={attendLimit} endTime={lateLimit} />
+            </>
           ) : (
             <>
               <SeminarSelector limitValue={attendValue} setLimitValue={setAttendValue} />

--- a/src/pages/senimarAttend/Card/MemberCardContent.tsx
+++ b/src/pages/senimarAttend/Card/MemberCardContent.tsx
@@ -16,7 +16,8 @@ const MemberCardContent = () => {
   const inputCode = [0, 0, 0, 0];
   const validCode = '1234'; // 임시
 
-  const handleAttendButtonClick = (nowTime: DateTime) => {
+  const handleAttendButtonClick = () => {
+    const nowTime = DateTime.now();
     setIsAttendable(nowTime < attendLimit);
     setIsCorrectCode(inputCode.join('') === validCode);
   };
@@ -27,7 +28,7 @@ const MemberCardContent = () => {
       <div className="flex justify-center">
         <FilledButton
           onClick={() => {
-            handleAttendButtonClick(DateTime.now());
+            handleAttendButtonClick();
           }}
         >
           출석

--- a/src/pages/senimarAttend/Card/MemberCardContent.tsx
+++ b/src/pages/senimarAttend/Card/MemberCardContent.tsx
@@ -1,20 +1,22 @@
 import React, { useState } from 'react';
 import FilledButton from '@components/Button/FilledButton';
+import { DateTime } from 'luxon';
 import Countdown from '../Countdown/Countdown';
 import SeminarInput from '../Input/SeminarInput';
 
 const MemberCardContent = () => {
   const [isAttendable, setIsAttendable] = useState(false);
   const [isCorrectCode, setIsCorrectCode] = useState(false);
-
   const isIncorrectCodeInPeriod = isAttendable && !isCorrectCode;
   const incorrectCodeMsg = '출석코드가 맞지 않습니다. 다시 입력해주세요.';
-  const attendLimit = new Date(); // 임시
-  attendLimit.setMinutes(attendLimit.getMinutes() + 5); // 임시
+  const [startTime, setStartTime] = useState(DateTime.now());
+  const attendLimit = startTime.plus({ days: 0, hours: 0, minutes: 0, seconds: 5 }); // 임시:이후 api에서 가져옴
+  const lateLimit = attendLimit.plus({ days: 0, hours: 0, minutes: 0, seconds: 5 }); // 임시: 이후 api에서 가져옴
+
   const inputCode = [0, 0, 0, 0];
   const validCode = '1234'; // 임시
 
-  const handleAttendButtonClick = (nowTime: Date) => {
+  const handleAttendButtonClick = (nowTime: DateTime) => {
     setIsAttendable(nowTime < attendLimit);
     setIsCorrectCode(inputCode.join('') === validCode);
   };
@@ -25,7 +27,7 @@ const MemberCardContent = () => {
       <div className="flex justify-center">
         <FilledButton
           onClick={() => {
-            handleAttendButtonClick(new Date());
+            handleAttendButtonClick(DateTime.now());
           }}
         >
           출석
@@ -36,8 +38,9 @@ const MemberCardContent = () => {
           <div>출석</div>
           <div>지각</div>
         </div>
-        <div className="grid content-between">
-          <Countdown />
+        <div className="grid content-between text-right">
+          <Countdown startTime={startTime} endTime={attendLimit} />
+          <Countdown startTime={attendLimit} endTime={lateLimit} />
         </div>
       </div>
     </>

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -18,6 +18,7 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
   };
 
   useEffect(() => {
+    setTimeDiff(endTime.diff(nowTime));
     id.current = setInterval(changeNowTime, 1000);
     return () => clearInterval(id.current);
   }, [nowTime]);
@@ -25,10 +26,6 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
   useEffect(() => {
     if (id.current) setLeftTime(endTime > nowTime ? timeDiff.toFormat('mm:ss') : '마감');
   }, [timeDiff]);
-
-  useEffect(() => {
-    setTimeDiff(endTime.diff(nowTime));
-  }, [nowTime]);
 
   return <p className="text-white">{startTime > nowTime ? endTime.diff(startTime).toFormat('mm:ss') : leftTime}</p>;
 };

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -9,8 +9,8 @@ interface countdownProps {
 
 const Countdown = ({ startTime, endTime }: countdownProps) => {
   const [nowTime, setNowTime] = useState(DateTime.now());
-  const id: { current: NodeJS.Timeout | undefined } = useRef();
-  const [diff, setDiff] = useState<Duration>(endTime.diff(startTime));
+  const id = useRef<NodeJS.Timeout>();
+  const [timeDiff, setTimeDiff] = useState<Duration>(endTime.diff(startTime));
   const [leftTime, setLeftTime] = useState('');
 
   const changeNowTime = () => {
@@ -23,11 +23,11 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
   }, [nowTime]);
 
   useEffect(() => {
-    if (id.current) setLeftTime(endTime > nowTime ? diff.toFormat('mm:ss') : '마감');
-  }, [diff]);
+    if (id.current) setLeftTime(endTime > nowTime ? timeDiff.toFormat('mm:ss') : '마감');
+  }, [timeDiff]);
 
   useEffect(() => {
-    setDiff(endTime.diff(nowTime));
+    setTimeDiff(endTime.diff(nowTime));
   }, [nowTime]);
 
   return <p className="text-white">{startTime > nowTime ? endTime.diff(startTime).toFormat('mm:ss') : leftTime}</p>;

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 
 interface countdownProps {
   startTime: DateTime;
@@ -9,7 +9,29 @@ interface countdownProps {
 
 const Countdown = ({ startTime, endTime }: countdownProps) => {
   const [nowTime, setNowTime] = useState(DateTime.now());
-  return <p className="text-white">02:30</p>;
+  const id: { current: NodeJS.Timeout | undefined } = useRef();
+  const [diff, setDiff] = useState<Duration>(endTime.diff(startTime));
+  const [leftTime, setLeftTime] = useState('');
+
+  const changeNowTime = () => {
+    setNowTime(DateTime.now());
+  };
+
+  useEffect(() => {
+    id.current = setInterval(changeNowTime, 1000);
+    return () => clearInterval(id.current);
+  }, [nowTime]);
+
+  useEffect(() => {
+    if (id.current) setLeftTime(endTime > nowTime ? diff.toFormat('mm:ss') : '마감');
+  }, [diff]);
+
+  useEffect(() => {
+    setDiff(endTime.diff(nowTime));
+  }, [nowTime]);
+
+  // console.log(diff.toFormat('mm:ss'));
+  return <p className="text-white">{leftTime}</p>;
 };
 
 export default Countdown;

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -31,7 +31,7 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
   }, [nowTime]);
 
   // console.log(diff.toFormat('mm:ss'));
-  return <p className="text-white">{leftTime}</p>;
+  return <p className="text-white">{startTime > nowTime ? endTime.diff(startTime).toFormat('mm:ss') : leftTime}</p>;
 };
 
 export default Countdown;

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const Countdown = () => {
-  return (
-    <>
-      <p className="text-white">02:30</p>
-      <p className="text-white">05:00</p>
-    </>
-  );
+import { DateTime } from 'luxon';
+
+interface countdownProps {
+  startTime: DateTime;
+  endTime: DateTime;
+}
+
+const Countdown = ({ startTime, endTime }: countdownProps) => {
+  const [nowTime, setNowTime] = useState(DateTime.now());
+  return <p className="text-white">02:30</p>;
 };
 
 export default Countdown;

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -30,7 +30,6 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
     setDiff(endTime.diff(nowTime));
   }, [nowTime]);
 
-  // console.log(diff.toFormat('mm:ss'));
   return <p className="text-white">{startTime > nowTime ? endTime.diff(startTime).toFormat('mm:ss') : leftTime}</p>;
 };
 

--- a/src/pages/senimarAttend/Selector/SeminarSelector.tsx
+++ b/src/pages/senimarAttend/Selector/SeminarSelector.tsx
@@ -24,7 +24,6 @@ const SeminarSelector = ({ limitValue, setLimitValue, children }: SeminarSelecto
       <p className="mr-[25px] mb-[5px] font-semibold">{children}</p>
       <Selector
         className="flex w-[92px] text-center"
-        label=""
         value={limitValue}
         onChange={handleTimeLimitChange}
         options={timeLimitlist}


### PR DESCRIPTION
## 분류
- [x] 기능 추가

## 연관 이슈
#284 #308 #207 #172 

## 작업 요약
회장과 회원 페이지의 카운트다운 기능을 구현했습니다.

## 작업 상세 설명
prop로 카운트다운이 시작하는 시간, 끝나는 시간 두 가지를 받습니다.
props로 시작하는 시간을 받아오는 이유는 카운트다운이 출석 시간을 카운트 다운하는 것과 지각 시간 카운트 다운 하는 것 두 가지가 있는데  지각 시간 카운트는 출석 시간 카운트가 끝나기 전까지 (지각 시간 카운트 시작 시간이 되기 전까지) 카운트다운 되지 않고 그대로 있어야 하기 때문입니다.

leftTime과 diff가 따로 존재하는 이유는 카운트다운이 00:00이 되면 '마감'으로 글씨가 바뀌어야 하는데, diff의 타입이 Duration이라 string값을 대입할 수 없고, Duration | string 으로 타입을 바꾸더라도 toFormat을 적용할 수 없어서 그냥 따로 주었습니다.

참고로 아직 api로 적용한 것이 아니라 새로고침을 해도 카운트 다운이 유지되지 않고, 회원 페이지와 회장 페이지의 카운트 다운이 따로놉니다. 이건 api 적용하면 해결될겁니당

## 리뷰 요구사항
> 10분?

## Preview 이미지
![image](https://user-images.githubusercontent.com/71930280/227775325-71039c88-0dab-417c-85da-1ae1c453e473.png)

