### PR TITLE
Feature/label없을시 margin 제거

### DIFF
--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -12,13 +12,8 @@ interface SelectorProps extends SelectProps {
 const Selector = ({ label, value, onChange, options, className, ...selectProps }: SelectorProps) => {
   return (
     <FormControl className={className} variant="standard">
-      <InputLabel>{label}</InputLabel>
-      <Select
-        className={`before:!border-pointBlue ${label ?? '!mt-0'}`}
-        value={value ?? ''}
-        onChange={onChange}
-        {...selectProps}
-      >
+      {label && <InputLabel>{label}</InputLabel>}
+      <Select className="before:!border-pointBlue" value={value ?? ''} onChange={onChange} {...selectProps}>
         {options.map((option) => (
           <MenuItem key={option.id} value={option.id}>
             {option.content}

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -13,7 +13,12 @@ const Selector = ({ label, value, onChange, options, className, ...selectProps }
   return (
     <FormControl className={className} variant="standard">
       <InputLabel>{label}</InputLabel>
-      <Select className="before:!border-pointBlue" value={value ?? ''} onChange={onChange} {...selectProps}>
+      <Select
+        className={`before:!border-pointBlue ${label ?? '!mt-0'}`}
+        value={value ?? ''}
+        onChange={onChange}
+        {...selectProps}
+      >
         {options.map((option) => (
           <MenuItem key={option.id} value={option.id}>
             {option.content}


### PR DESCRIPTION
## 연관 이슈
- #325 

## 작업 요약
- selector가 label때문에 margin 16px이 존재하는데, label이 없더라도 margin이 유지되어, 이를 제거
- 
## Preview 이미지
변경전, 변경후
![image](https://user-images.githubusercontent.com/81643702/228439867-76d4711f-a4f2-4238-aa34-f59faa7a9681.png)

![image](https://user-images.githubusercontent.com/81643702/228439531-a1347bad-8f45-41d3-8a36-1690cefd39c5.png)
