### PR TITLE
Feature/모달창 색 변경 #327

### DIFF
--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -23,7 +23,12 @@ const ActionModal = ({
   onActionButonClick,
 }: ActionModalProps) => {
   return (
-    <Dialog open={open} PaperProps={{ className: 'px-2 py-1' }} fullWidth={Boolean(modalWidth)} maxWidth={modalWidth}>
+    <Dialog
+      open={open}
+      PaperProps={{ className: '!bg-subBlack brightness-125 !bg-none px-2 py-1' }}
+      fullWidth={Boolean(modalWidth)}
+      maxWidth={modalWidth}
+    >
       <DialogTitle className="!font-bold text-pointBlue">{title}</DialogTitle>
       <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
       <DialogActions>


### PR DESCRIPTION
## 연관 이슈
- close #327

## 작업 요약
- 모달창 색 subBlack으로 변경

## 작업 상세 설명
- 기존 모달창 색이 subBlack이 아니었기에 변경
- 디자인채널 투표대로 brightness 125
- 기존 mui 모달창에 background이미지 때문에 원하는색이 안나왔었기에, 이를 [bg-none](https://tailwindcss.com/docs/background-image)으로 제거

## 리뷰 요구사항
- 0.1분
- PaperProps에 className속성만 보시면 됩니다!

## Preview 이미지
![image](https://user-images.githubusercontent.com/81643702/229339652-bf9b3e39-834c-4939-8979-6181ff2a1af5.png)
