### PR TITLE
Feature/회원가입 인풋 호출부 구현 #293

### DIFF
--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -28,7 +28,7 @@ const SignUp = () => {
       <Box className="h-[492px] w-[690px] border border-pointBlue px-24 py-14">
         <Stack className="relative h-full w-full">
           <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
-          <Typography className="whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
+          <Typography className="!mb-8 whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
           {stepInputSection[currentStep]}
           <div className="absolute right-0 bottom-0">
             <OutlinedButton>다음</OutlinedButton>

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -15,6 +15,13 @@ const SignUp = () => {
     3: '이메일 주소를 입력해주세요.\n입력한 이메일 주소로 인증 코드가 발송됩니다.',
   };
 
+  const stepInputSection = {
+    // TODO 스텝 별 인풋 컴포넌트 추가 예정
+    1: null,
+    2: null,
+    3: null,
+  };
+
   return (
     <div className="grid h-screen place-content-center place-items-center">
       <Logo className="mb-9 w-48" />
@@ -22,6 +29,7 @@ const SignUp = () => {
         <Stack className="relative h-full w-full">
           <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
           <Typography className="whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
+          {stepInputSection[currentStep]}
           <div className="absolute right-0 bottom-0">
             <OutlinedButton>다음</OutlinedButton>
           </div>


### PR DESCRIPTION
## 연관 이슈
- #293

## 작업 요약
- 인풋 내용 부분 단계별 컴포넌 넣을 수 있도록 호출부 작성

## 작업 상세 설명
- 단계별 인풋 내용 부분 UI 구현 나눠서 PR 올리기 위해 공통적으로 사용되는 호출부 먼저 PR 올립니다.
- `stepInputSection` 객테의 null 부분에 각 단계 인풋 컴포넌트를 넣으면 단계 안내문구 아래에 인풋 내용 부분 렌더링 되도록 하였습니다.

## 리뷰 요구사항
- 0.1분
