### PR TITLE
Feature/공통 배경 인풋 구현 #339

### DIFF
--- a/src/components/Input/BackgroundInput.tsx
+++ b/src/components/Input/BackgroundInput.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { TextField, StandardTextFieldProps } from '@mui/material';
+
+interface BackgroundInputProps extends StandardTextFieldProps {
+  value: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+const BackgroundInput = ({ value, onChange, error, ...standardTextFieldProps }: BackgroundInputProps) => {
+  return (
+    <TextField
+      InputProps={{
+        className: `${!error && 'before:!border-pointBlue bg-pointBlue/5'} h-12`,
+      }}
+      value={value}
+      onChange={onChange}
+      error={error}
+      {...standardTextFieldProps}
+      variant="standard"
+      sx={{ '.MuiFormLabel-root[data-shrink=false]': { top: 8 } }}
+    />
+  );
+};
+
+export default BackgroundInput;


### PR DESCRIPTION
## 연관 이슈
- Close #339

## 작업 요약
- 반투명 포인트 컬러가 배경으로 들어간 인풋 공통 컴포넌트 구현

## 작업 상세 설명
- 배경색 추가 `bg-pointBlue/5`
- 높이 조정 `h-12`
- 라벨 위치 조정 `top: 8`
- 라벨 위치 조정을 하지 않으면 좌측 이미지 처럼 라벨이 중앙이 아닌 위쪽으로 위치되여 우측 이미지 처럼 변경되도록 조정해주었습니다. [참고](https://stackoverflow.com/questions/53854030/set-textfield-height-material-ui)
- <img width="169" alt="image" src="https://user-images.githubusercontent.com/78250089/232814537-0b4c1cb3-6d69-4043-9410-adb0b8e4c71e.png"> <img width="190" alt="image" src="https://user-images.githubusercontent.com/78250089/232814617-1d1a9b00-0514-4d2a-a1fa-695454c59be4.png">

## 리뷰 요구사항
- 5분
- `StandardInput` 컴포넌트에서 확장된 부분 코멘트로 남겨두겠습니다.

## Preview 이미지
<img width="270" alt="image" src="https://user-images.githubusercontent.com/78250089/232816020-013b3699-9039-47fc-b908-0b5aaa3c7643.png">

### Preview 예제코드
```tsx
<BackgroundInput
  value=""
  label="ID"
  onChange={() => {
    // TODO
  }}
/>
```