### PR TITLE
Feature/mui typography variant 커스텀 구현

### DIFF
--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -13,7 +13,40 @@ const muiTheme = createTheme({
   },
   typography: {
     fontFamily: ['IBM Plex Sans KR', 'system-ui', 'sans-serif'].join(','),
+    h1: {
+      fontSize: '28px',
+    },
+    h3: {
+      fontSize: '20px',
+    },
+    paragraph: {
+      fontSize: '16px',
+    },
+    small: {
+      fontSize: '10px',
+    },
   },
 });
+
+declare module '@mui/material/styles' {
+  interface TypographyVariants {
+    paragraph: React.CSSProperties;
+    small: React.CSSProperties;
+  }
+
+  // allow configuration using `createTheme`
+  interface TypographyVariantsOptions {
+    paragraph?: React.CSSProperties;
+    small?: React.CSSProperties;
+  }
+}
+
+// Update the Typography's variant prop options
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    paragraph: true;
+    small: true;
+  }
+}
 
 export default muiTheme;


### PR DESCRIPTION
## 연관 이슈
- close #343

## 작업 요약
- mui typography variant 커스텀 구현
- tailwind.config.js랑 똑같이 해줬습니다! 
- 참고) tailwind.config.js
![image](https://user-images.githubusercontent.com/81643702/235083596-eeab5525-b143-41c3-8725-0741d29ead7e.png)
- 추후에 수정하려면 해당 [MUI 링크](https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants) 참고하시면 됩니다! typescript에서, variant 커스텀 하는 방법 나와있습니다!
## 리뷰 요구사항
- 2분

## Preview 이미지
![image](https://user-images.githubusercontent.com/81643702/235082373-285fc209-068a-4a6c-84b3-2ff018950c84.png)


### Preview 예제코드
```tsx
import React from 'react';
import { Typography } from '@mui/material';

const Intro = () => {
  return (
    <div>
      <Typography variant="h1">h1</Typography>
      <Typography variant="h3">h3</Typography>
      <Typography variant="paragraph">paragraph</Typography>
      <Typography variant="small">small</Typography>
    </div>
  );
};

export default Intro;


```