### PR TITLE
Feature/회원가입 인증 메일 안내 모달 UI #294

### DIFF
--- a/src/components/Modal/MailAuthenticationModal.tsx
+++ b/src/components/Modal/MailAuthenticationModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Stack, Typography } from '@mui/material';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import ConfirmModal from './ConfirmModal';
+
+interface MailAuthenticationModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const MailAuthenticationModal = ({ open, onClose }: MailAuthenticationModalProps) => {
+  const modalContents =
+    '이메일 주소가 정확한지 확인해 주세요.\n메일 서비스에 따라 인증 메일 발송이 늦어질 수 있습니다.';
+
+  return (
+    <ConfirmModal open={open} onClose={onClose} title="인증 메일이 오지 않았나요?">
+      <Typography className="h-24 w-[440px] whitespace-pre">{modalContents}</Typography>
+      <Stack className="flex justify-end space-x-2" direction="row">
+        <OutlinedButton>다른 이메일로 인증</OutlinedButton>
+        <OutlinedButton>인증 메일 재발송</OutlinedButton>
+      </Stack>
+    </ConfirmModal>
+  );
+};
+
+export default MailAuthenticationModal;


### PR DESCRIPTION
## 연관 이슈
- Close #294

## 작업 요약
- 회원가입 페이지에 필요한 인증 메일 안내 모달이 로그인 페이지등에도 사용될 수 있을 것 같아서 공통 컴포넌트로 만들었습니다.

## 작업 상세 설명
- 제목, 내용 구성
- 버튼 UI
- 버튼 기능은 아직 넣지 않은 상태입니다! 기능 확장되면 props 추가될 예정입니다!
 
## 리뷰 요구사항
- 5분

## Preview 이미지
<img width="503" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a9fec943-313c-48a3-abb5-8e64ea69e55e">
