### PR TITLE
Feature/회원가입 단계별 인풋 내용 부분 UI 구성 #293

### DIFF
--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Stack } from '@mui/material';
+
+import BackgroundInput from '@components/Input/BackgroundInput';
+
+const SignUpFirstInputSection = () => {
+  return (
+    <Stack className="space-y-4">
+      <BackgroundInput
+        value=""
+        label="아이디"
+        onChange={() => {
+          // TODO
+        }}
+      />
+      <BackgroundInput
+        value=""
+        label="비밀번호"
+        onChange={() => {
+          // TODO
+        }}
+      />
+      <BackgroundInput
+        value=""
+        label="비밀번호 확인"
+        onChange={() => {
+          // TODO
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default SignUpFirstInputSection;

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Stack } from '@mui/material';
+
+import BackgroundInput from '@components/Input/BackgroundInput';
+
+const SignUpSecondInputSection = () => {
+  return (
+    <Stack className="space-y-4">
+      <Stack spacing={2} direction="row" justifyContent="space-between">
+        <BackgroundInput
+          className="w-full"
+          value=""
+          label="이름"
+          onChange={() => {
+            // TODO
+          }}
+        />
+        <BackgroundInput
+          className="w-full"
+          value=""
+          label="닉네임"
+          onChange={() => {
+            // TODO
+          }}
+        />
+      </Stack>
+      <BackgroundInput
+        value=""
+        label="학번"
+        onChange={() => {
+          // TODO
+        }}
+      />
+      {/* TODO "생일 DatePicker" */}
+    </Stack>
+  );
+};
+
+export default SignUpSecondInputSection;

--- a/src/pages/SignUp/Section/SignUpThirdInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpThirdInputSection.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Stack } from '@mui/material';
+
+import BackgroundInput from '@components/Input/BackgroundInput';
+
+const SignUpThirdInputSection = () => {
+  return (
+    <Stack className=" space-y-4">
+      {/* TODO 인증요청 버튼 포함 이메일 인풋 */}
+      <BackgroundInput
+        value=""
+        label="인증코드"
+        onChange={() => {
+          // TODO
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default SignUpThirdInputSection;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -6,6 +6,7 @@ import StepProgress from '@components/Progress/StepProgress';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import SignUpFirstInputSection from './Section/SignUpFirstInputSection';
 import SignUpSecondInputSection from './Section/SignUpSecondInputSection';
+import SignUpThirdInputSection from './Section/SignUpThirdInputSection';
 
 const SignUp = () => {
   const TOTAL_STEPS = 3;
@@ -21,7 +22,7 @@ const SignUp = () => {
     // TODO 스텝 별 인풋 컴포넌트 추가 예정
     1: <SignUpFirstInputSection />,
     2: <SignUpSecondInputSection />,
-    3: null,
+    3: <SignUpThirdInputSection />,
   };
 
   return (

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -4,6 +4,7 @@ import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { Box, Stack, Typography } from '@mui/material';
 import StepProgress from '@components/Progress/StepProgress';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import SignUpFirstInputSection from './Section/SignUpFirstInputSection';
 
 const SignUp = () => {
   const TOTAL_STEPS = 3;
@@ -17,7 +18,7 @@ const SignUp = () => {
 
   const stepInputSection = {
     // TODO 스텝 별 인풋 컴포넌트 추가 예정
-    1: null,
+    1: <SignUpFirstInputSection />,
     2: null,
     3: null,
   };

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -5,6 +5,7 @@ import { Box, Stack, Typography } from '@mui/material';
 import StepProgress from '@components/Progress/StepProgress';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import SignUpFirstInputSection from './Section/SignUpFirstInputSection';
+import SignUpSecondInputSection from './Section/SignUpSecondInputSection';
 
 const SignUp = () => {
   const TOTAL_STEPS = 3;
@@ -19,7 +20,7 @@ const SignUp = () => {
   const stepInputSection = {
     // TODO 스텝 별 인풋 컴포넌트 추가 예정
     1: <SignUpFirstInputSection />,
-    2: null,
+    2: <SignUpSecondInputSection />,
     3: null,
   };
 


### PR DESCRIPTION
## 연관 이슈
- #293

## 작업 요약
- 회원가입 1, 2, 3 단계에 해당하는 UI 구성하였습니다.

## 작업 상세 설명
- 1단계 `아이디`, `비밀번호`, `비밀번호 확인` 인풋 구성
- 2단계 `이름`, `닉네임`, `학번` 인풋 구성 (생일의 경우 DatePicker 커스텀 필요하여 별도 이슈로 진행 예정)
- 3단계 `인증코드` 인풋 구성 (이메일은 인증 요청 버튼이 들어간 인풋으로 커스텀 필요하여 별도 이슈로 진행 예정)

## 리뷰 요구사항
- 3분
- 각 단계별로 Section 파일 만들어 인풋 넣어준 것 말고는 주요 변경 사항 없습니다!
- `SignUp.tsx` 파일의 `currentStep` 숫자 조정을 통해 각 단계 조회 가능합니다.

## Preview 이미지
<img width="200" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/522949fd-4cb9-40c2-9076-63b63e94f9ca">  <img width="200" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/f66fa42e-6f08-46dc-b864-b41ec13a93b5"> <img width="200" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/dcd600a7-e355-4c43-9c23-84328841c1a0">
