### PR TITLE
Feature/회원가입 1단계 기능 구현 #295

### DIFF
--- a/src/components/Input/BackgroundInput.tsx
+++ b/src/components/Input/BackgroundInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { TextField, StandardTextFieldProps } from '@mui/material';
 
 interface BackgroundInputProps extends StandardTextFieldProps {
@@ -7,20 +7,26 @@ interface BackgroundInputProps extends StandardTextFieldProps {
   onChange: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-const BackgroundInput = ({ value, onChange, error, ...standardTextFieldProps }: BackgroundInputProps) => {
-  return (
-    <TextField
-      InputProps={{
-        className: `${!error && 'before:!border-pointBlue bg-pointBlue/5'} h-12`,
-      }}
-      value={value}
-      onChange={onChange}
-      error={error}
-      {...standardTextFieldProps}
-      variant="standard"
-      sx={{ '.MuiFormLabel-root[data-shrink=false]': { top: 8 } }}
-    />
-  );
-};
+const BackgroundInput = forwardRef(
+  (
+    { value, onChange, error, ...standardTextFieldProps }: BackgroundInputProps,
+    ref: React.ForwardedRef<HTMLDivElement>,
+  ) => {
+    return (
+      <TextField
+        ref={ref}
+        InputProps={{
+          className: `${!error && 'before:!border-pointBlue bg-pointBlue/5'} h-12`,
+        }}
+        value={value}
+        onChange={onChange}
+        error={error}
+        {...standardTextFieldProps}
+        variant="standard"
+        sx={{ '.MuiFormLabel-root[data-shrink=false]': { top: 8 } }}
+      />
+    );
+  },
+);
 
 export default BackgroundInput;

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -9,15 +9,15 @@ import OutlinedButton from '@components/Button/OutlinedButton';
 import signUpPageState from '../SignUp.recoil';
 
 const SignUpFirstInputSection = () => {
+  const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
+  const setSignUpPageState = useSetRecoilState(signUpPageState);
+
   const {
     control,
     getValues,
     handleSubmit,
     formState: { isSubmitting },
   } = useForm({ mode: 'onBlur' });
-  const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
-
-  const setSignUpPageState = useSetRecoilState(signUpPageState);
 
   const handleFirstStepFormSubmit: SubmitHandler<FieldValues> = ({ loginId, password }) => {
     setSignUpPageState((prev) => ({ ...prev, loginId, password }));

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -47,7 +47,15 @@ const SignUpFirstInputSection = () => {
           },
         }}
         render={({ field, fieldState: { error } }) => {
-          return <BackgroundInput label="비밀번호" {...field} error={Boolean(error)} helperText={error?.message} />;
+          return (
+            <BackgroundInput
+              type="password"
+              label="비밀번호"
+              {...field}
+              error={Boolean(error)}
+              helperText={error?.message}
+            />
+          );
         }}
       />
       <Controller
@@ -67,6 +75,7 @@ const SignUpFirstInputSection = () => {
         render={({ field, fieldState: { error } }) => {
           return (
             <BackgroundInput
+              type="password"
               label="비밀번호 확인"
               {...field}
               error={Boolean(error)}

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -16,7 +16,7 @@ const SignUpFirstInputSection = () => {
     control,
     getValues,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isValid },
   } = useForm({ mode: 'onBlur' });
 
   const handleFirstStepFormSubmit: SubmitHandler<FieldValues> = ({ loginId, password }) => {
@@ -99,7 +99,7 @@ const SignUpFirstInputSection = () => {
       />
 
       <div className="absolute right-0 bottom-0">
-        <OutlinedButton type="submit" disabled={isSubmitting}>
+        <OutlinedButton type="submit" disabled={!isValid || isSubmitting}>
           다음
         </OutlinedButton>
       </div>

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@mui/material';
 import { useForm, Controller } from 'react-hook-form';
 
 import BackgroundInput from '@components/Input/BackgroundInput';
+import OutlinedButton from '@components/Button/OutlinedButton';
 
 const SignUpFirstInputSection = () => {
   const { control, getValues } = useForm({ mode: 'onBlur' });
@@ -74,6 +75,10 @@ const SignUpFirstInputSection = () => {
           );
         }}
       />
+
+      <div className="absolute right-0 bottom-0">
+        <OutlinedButton>다음</OutlinedButton>
+      </div>
     </Stack>
   );
 };

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { useState } from 'react';
 import { Stack } from '@mui/material';
 import { useForm, Controller, SubmitHandler, FieldValues } from 'react-hook-form';

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -29,11 +29,23 @@ const SignUpFirstInputSection = () => {
           return <BackgroundInput label="아이디" {...field} error={Boolean(error)} helperText={error?.message} />;
         }}
       />
-      <BackgroundInput
-        value=""
-        label="비밀번호"
-        onChange={() => {
-          // TODO
+      <Controller
+        name="password"
+        defaultValue=""
+        control={control}
+        rules={{
+          required: '필수 정보입니다.',
+          minLength: {
+            value: 8,
+            message: '8글자 이상 입력해주세요.',
+          },
+          pattern: {
+            value: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+            message: '8~20자 영문과 숫자를 사용하세요.',
+          },
+        }}
+        render={({ field, fieldState: { error } }) => {
+          return <BackgroundInput label="비밀번호" {...field} error={Boolean(error)} helperText={error?.message} />;
         }}
       />
       <BackgroundInput

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
+import React, { useState } from 'react';
 import { Stack } from '@mui/material';
 import { useForm, Controller } from 'react-hook-form';
 
 import BackgroundInput from '@components/Input/BackgroundInput';
 
 const SignUpFirstInputSection = () => {
-  const { control } = useForm({ mode: 'onBlur' });
+  const { control, getValues } = useForm({ mode: 'onBlur' });
+  const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
 
   return (
     <Stack component="form" className="space-y-4">
@@ -48,11 +49,29 @@ const SignUpFirstInputSection = () => {
           return <BackgroundInput label="비밀번호" {...field} error={Boolean(error)} helperText={error?.message} />;
         }}
       />
-      <BackgroundInput
-        value=""
-        label="비밀번호 확인"
-        onChange={() => {
-          // TODO
+      <Controller
+        name="passwordConfirm"
+        defaultValue=""
+        control={control}
+        rules={{
+          required: '필수 정보입니다.',
+          validate: {
+            confirmMatchPassward: (value) => {
+              if (getValues('password') !== value) return '비밀번호가 일치하지 않습니다.';
+              setPasswordConfirmSuccessMsg('비밀번호가 일치합니다.');
+              return undefined;
+            },
+          },
+        }}
+        render={({ field, fieldState: { error } }) => {
+          return (
+            <BackgroundInput
+              label="비밀번호 확인"
+              {...field}
+              error={Boolean(error)}
+              helperText={error?.message || passwordConfirmSuccessMsg}
+            />
+          );
         }}
       />
     </Stack>

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,17 +1,29 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useState } from 'react';
 import { Stack } from '@mui/material';
-import { useForm, Controller } from 'react-hook-form';
+import { useForm, Controller, SubmitHandler, FieldValues } from 'react-hook-form';
+import { useSetRecoilState } from 'recoil';
 
 import BackgroundInput from '@components/Input/BackgroundInput';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import signUpPageState from '../SignUp.recoil';
 
 const SignUpFirstInputSection = () => {
-  const { control, getValues } = useForm({ mode: 'onBlur' });
+  const {
+    control,
+    getValues,
+    handleSubmit,
+  } = useForm({ mode: 'onBlur' });
   const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
 
+  const setSignUpPageState = useSetRecoilState(signUpPageState);
+
+  const handleFirstStepFormSubmit: SubmitHandler<FieldValues> = ({ loginId, password }) => {
+    setSignUpPageState((prev) => ({ ...prev, loginId, password }));
+  };
+
   return (
-    <Stack component="form" spacing={2}>
+    <Stack component="form" spacing={2} onSubmit={handleSubmit(handleFirstStepFormSubmit)}>
       <Controller
         name="loginId"
         defaultValue=""
@@ -86,7 +98,7 @@ const SignUpFirstInputSection = () => {
       />
 
       <div className="absolute right-0 bottom-0">
-        <OutlinedButton>다음</OutlinedButton>
+        <OutlinedButton type="submit">다음</OutlinedButton>
       </div>
     </Stack>
   );

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -8,7 +8,11 @@ import BackgroundInput from '@components/Input/BackgroundInput';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import signUpPageState from '../SignUp.recoil';
 
-const SignUpFirstInputSection = () => {
+interface SignUpFirstInputSectionProps {
+  setCurrentStep: React.Dispatch<React.SetStateAction<1 | 2 | 3>>;
+}
+
+const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProps) => {
   const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
   const setSignUpPageState = useSetRecoilState(signUpPageState);
 
@@ -21,6 +25,7 @@ const SignUpFirstInputSection = () => {
 
   const handleFirstStepFormSubmit: SubmitHandler<FieldValues> = ({ loginId, password }) => {
     setSignUpPageState((prev) => ({ ...prev, loginId, password }));
+    setCurrentStep(2);
   };
 
   return (

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -13,6 +13,7 @@ const SignUpFirstInputSection = () => {
     control,
     getValues,
     handleSubmit,
+    formState: { isSubmitting },
   } = useForm({ mode: 'onBlur' });
   const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
 
@@ -98,7 +99,9 @@ const SignUpFirstInputSection = () => {
       />
 
       <div className="absolute right-0 bottom-0">
-        <OutlinedButton type="submit">다음</OutlinedButton>
+        <OutlinedButton type="submit" disabled={isSubmitting}>
+          다음
+        </OutlinedButton>
       </div>
     </Stack>
   );

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,16 +1,32 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { Stack } from '@mui/material';
+import { useForm, Controller } from 'react-hook-form';
 
 import BackgroundInput from '@components/Input/BackgroundInput';
 
 const SignUpFirstInputSection = () => {
+  const { control } = useForm({ mode: 'onBlur' });
+
   return (
-    <Stack className="space-y-4">
-      <BackgroundInput
-        value=""
-        label="아이디"
-        onChange={() => {
-          // TODO
+    <Stack component="form" className="space-y-4">
+      <Controller
+        name="loginId"
+        defaultValue=""
+        control={control}
+        rules={{
+          required: '필수 정보입니다.',
+          minLength: {
+            value: 4,
+            message: '4글자 이상 입력해주세요.',
+          },
+          pattern: {
+            value: /^[a-zA-Z0-9_]{4,12}$/,
+            message: '4~12자 영어, 숫자, _ 만 가능합니다.',
+          },
+        }}
+        render={({ field, fieldState: { error } }) => {
+          return <BackgroundInput label="아이디" {...field} error={Boolean(error)} helperText={error?.message} />;
         }}
       />
       <BackgroundInput

--- a/src/pages/SignUp/SignUp.recoil.ts
+++ b/src/pages/SignUp/SignUp.recoil.ts
@@ -1,0 +1,17 @@
+import { atom } from 'recoil';
+
+const signUpPageState = atom({
+  key: 'signUpPageState',
+  default: {
+    loginId: '',
+    email: '',
+    realName: '',
+    nickname: '',
+    authCode: '',
+    birthday: '',
+    studentId: '',
+    password: '',
+  },
+});
+
+export default signUpPageState;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { Box, Stack, Typography } from '@mui/material';
@@ -10,7 +10,7 @@ import SignUpThirdInputSection from './Section/SignUpThirdInputSection';
 const SignUp = () => {
   const TOTAL_STEPS = 3;
 
-  const currentStep = 1; // TODO 추후 state로 관리
+  const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1);
   const stepInfoMsg = {
     1: '로그인에 사용할\n아이디와 비밀번호를 등록해 주세요.',
     2: '프로필 정보를 등록해 주세요.',
@@ -18,7 +18,7 @@ const SignUp = () => {
   };
 
   const stepInputSection = {
-    1: <SignUpFirstInputSection />,
+    1: <SignUpFirstInputSection setCurrentStep={setCurrentStep} />,
     2: <SignUpSecondInputSection />,
     3: <SignUpThirdInputSection />,
   };

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { Box, Stack, Typography } from '@mui/material';
 import StepProgress from '@components/Progress/StepProgress';
-import OutlinedButton from '@components/Button/OutlinedButton';
 import SignUpFirstInputSection from './Section/SignUpFirstInputSection';
 import SignUpSecondInputSection from './Section/SignUpSecondInputSection';
 import SignUpThirdInputSection from './Section/SignUpThirdInputSection';
@@ -32,9 +31,6 @@ const SignUp = () => {
           <StepProgress className="mb-2 w-32" currentStep={currentStep} totalStep={TOTAL_STEPS} />
           <Typography className="!mb-8 whitespace-pre !font-semibold">{stepInfoMsg[currentStep]}</Typography>
           {stepInputSection[currentStep]}
-          <div className="absolute right-0 bottom-0">
-            <OutlinedButton>다음</OutlinedButton>
-          </div>
         </Stack>
       </Box>
     </div>


### PR DESCRIPTION
## 연관 이슈
- #295 

## 작업 요약
회원가입 1단계
- 아이디
- 비밀번호
- 비밀번호 확인

에 프론트에서 처리해줄 수 있는 기능 구현하였습니다.

## 작업 상세 설명
- [x] 아이디 유효성 검사
- [x] 비밀번호 유효성 검사
- [x] 비밀번호 일치 확인
- [x] 다음 버튼 클릭 시 전체 필드 유효성 검사
- [x] 다음 버튼 모든 필드 유효성 검사 통과 못할 시 비활성화
- [x] 다음 버튼 클릭 후 이상 없으면 단계 이동

추가로 작업해야 하는 기능
- 아이디 중복 체크 기능 (API 사용)
- 비밀번호 변경 시 비밀번호 확인 에러 상태 해당 필드 blur하지 않아도 바로 반영되도록 처리
- 테스트 코드 짜기

## 리뷰 요구사항
- ~~#378 선행 PR 먼저 리뷰 부탁드립니다!~~ (머지 완료!)
- 예상 소요 시간 `20분` (라이브러리 숙련 정도에 따라 리뷰 시간 상이할 듯 합니다!)
- 디자인 관련해서는별도 PR에서 처리해줄 예정이니 이 PR에서는 디자인 관련 리뷰 패스하셔도 됩니다!
(인풋 배경색이 디자인과 다르다거나 하는 등등 있을 겁니다!)
- `react-hook-form`, `recoil` 사용한 부분 익숙치 않아서 중점적으로 리뷰 부탁드립니다!
- `Controller` 사용한 부분이라거나 중복적인 부분 리팩토링 할 부분 기능 구현 완료 후 싹 한 번 검토해볼 예정이긴 합니다만 좋은 의견 있다면 여기서도 많은 피드백 부탁드립니다!

## Preview 이미지
<img width="707" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/6db48282-d046-46b1-9f5e-558411080234">
