### PR TITLE
Feature/회원가입 API 틀 생성 #385

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -64,3 +64,18 @@ export interface StudyListInfo {
   headMember: StudyMemberInfo;
   memberList: StudyMemberInfo[];
 }
+
+export interface SignUpInfo {
+  loginId: string;
+  email: string;
+  realName: string;
+  nickname: string;
+  authCode: string;
+  birthday: string;
+  studentId: string;
+  password: string;
+}
+
+export interface SignUpDuplication {
+  duplicate: boolean;
+}

--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { useQuery, useMutation } from 'react-query';
+import { SignUpDuplication, SignUpInfo } from './dto';
+
+const signUpKeys = {
+  idDuplication: ['sighUp', 'duplication', 'loginId'] as const,
+  emailDuplication: ['sighUp', 'duplication', 'email'] as const,
+  studentIdDuplication: ['sighUp', 'duplication', 'studentId'] as const,
+};
+
+const useSignUpMutation = () => {
+  const fetcher = (signUpInfo: SignUpInfo) => axios.post('/sign-up', signUpInfo);
+
+  return useMutation(fetcher);
+};
+
+const useEmailAuthMutation = () => {
+  const fetcher = (email: string) => axios.post('/sign-up/email-auth', { email });
+
+  return useMutation(fetcher);
+};
+
+const useCheckLoginIdDuplicationQuery = ({ loginId }: { loginId: string }) => {
+  const fetcher = () => axios.get('/sign-up/exists/login-id', { params: { loginId } }).then(({ data }) => data);
+
+  return useQuery<SignUpDuplication>(signUpKeys.idDuplication, fetcher);
+};
+
+const useCheckEmailDuplicationQuery = ({ email }: { email: string }) => {
+  const fetcher = () => axios.get('/sign-up/exists/email', { params: { email } }).then(({ data }) => data);
+
+  return useQuery<SignUpDuplication>(signUpKeys.emailDuplication, fetcher);
+};
+
+const useCheckStudentIdDuplicationQuery = ({ studentId }: { studentId: string }) => {
+  const fetcher = () => axios.get('/sign-up/exists/student-id', { params: { studentId } }).then(({ data }) => data);
+
+  return useQuery<SignUpDuplication>(signUpKeys.studentIdDuplication, fetcher);
+};
+
+export {
+  useSignUpMutation,
+  useEmailAuthMutation,
+  useCheckLoginIdDuplicationQuery,
+  useCheckEmailDuplicationQuery,
+  useCheckStudentIdDuplicationQuery,
+};


### PR DESCRIPTION
## 연관 이슈
- Close #385

## 작업 요약

회원가입할 때 필요한 API 틀 작성하였습니다.

## 작업 상세 설명

- `reactQuery` + `axios` 사용하여 API 받아올 수 있도록 구현하였습니다.
- 회원가입할 때 필요한 아래 API들 받아오도록 해주었습니다.
  - 회원가입
  - 이메일 인증
  - 아이디 중복 체크
  - 이메일 중복 체크
  - 학번 중복 체크

## 리뷰 요구사항
- 10분 소요 예상
- query key 사용하는 부분 배열에 공통되는 부분과 차이 나는 부분 구별해서 지정해주었는데 괜찮은 지 리뷰 부탁드립니다!

## Preview 코드
```tsx
import {
  useSignUpMutation,
  useEmailAuthMutation,
  useCheckLoginIdDuplicationQuery,
  useCheckEmailDuplicationQuery,
  useCheckStudentIdDuplicationQuery,
} from '@api/signUpApi';
...

const Example = () => {
  const signUpPageValue = useRecoilValue(signUpPageState);
  const { mutate: createAuthMutation } = useSignUpMutation();
  const { mutate: emailAuthMutation } = useEmailAuthMutation();
  const { data: isUniqueLoginId } = useCheckLoginIdDuplicationQuery({ loginId: signUpPageValue.loginId });
  const { data: isUniqueEmail } = useCheckEmailDuplicationQuery({ email: signUpPageValue.email });
  const { data: isUniqueStudentId } = useCheckStudentIdDuplicationQuery({ studentId: signUpPageValue.studentId });
  ...
}
```

