### PR TITLE
Featrue/기본 폰트 크기 16 - 14px로 변경

### DIFF
--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -20,7 +20,7 @@ const muiTheme = createTheme({
       fontSize: '20px',
     },
     paragraph: {
-      fontSize: '16px',
+      fontSize: '14px',
     },
     small: {
       fontSize: '10px',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ module.exports = withMT({
       fontSize: {
         h1: '28px',
         h3: '20px',
-        paragraph: '16px',
+        paragraph: '14px',
         small: '10px',
       },
       spacing: {


### PR DESCRIPTION
## 연관 이슈
- close #389

## 작업 요약
- 기본 폰트 크기 paragraph 16 -> 14px로 변경 (mui, tailiwind 둘 다)

## 리뷰 요구사항
- 30 초

## Preview 이미지
