### PR TITLE
Feature/버튼 disable시 border색 변경 #397

### DIFF
--- a/src/components/Button/FilledButton.tsx
+++ b/src/components/Button/FilledButton.tsx
@@ -15,7 +15,7 @@ const FilledButton = ({ children, onClick, disabled, type, small }: OutlinedButt
       variant="contained"
       className={`${
         small && '!text-small'
-      } " h-fit !rounded-sm !py-2 !px-6 !font-semibold !text-subBlack hover:!opacity-80 hover:!shadow-none disabled:!bg-subGray`}
+      } h-fit !rounded-sm !py-2 !px-6 !font-semibold !text-subBlack hover:!opacity-80 hover:!shadow-none disabled:!bg-subGray`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/FilledButton.tsx
+++ b/src/components/Button/FilledButton.tsx
@@ -15,7 +15,7 @@ const FilledButton = ({ children, onClick, disabled, type, small }: OutlinedButt
       variant="contained"
       className={`${
         small && '!text-small'
-      } "h-fit !rounded-sm !py-2 !px-6 !font-semibold !leading-4 !text-subBlack hover:!opacity-80 hover:!shadow-none`}
+      } "h-fit !rounded-sm !py-2 !px-6 !font-semibold !text-subBlack hover:!opacity-80 hover:!shadow-none`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/FilledButton.tsx
+++ b/src/components/Button/FilledButton.tsx
@@ -15,7 +15,7 @@ const FilledButton = ({ children, onClick, disabled, type, small }: OutlinedButt
       variant="contained"
       className={`${
         small && '!text-small'
-      } "h-fit !rounded-sm !py-2 !px-6 !font-semibold !text-subBlack hover:!opacity-80 hover:!shadow-none`}
+      } " h-fit !rounded-sm !py-2 !px-6 !font-semibold !text-subBlack hover:!opacity-80 hover:!shadow-none disabled:!bg-subGray`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/OutlinedButton.tsx
+++ b/src/components/Button/OutlinedButton.tsx
@@ -15,7 +15,9 @@ const OutlinedButton = ({ children, onClick, disabled, type, small, startIcon, e
   return (
     <Button
       variant="outlined"
-      className={`${small && '!text-small'} h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold`}
+      className={`${small && '!text-small'} ${
+        !disabled && '!border-pointBlue'
+      } h-fit !rounded-sm !py-2 !px-6 !font-semibold`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/OutlinedButton.tsx
+++ b/src/components/Button/OutlinedButton.tsx
@@ -15,7 +15,7 @@ const OutlinedButton = ({ children, onClick, disabled, type, small, startIcon, e
   return (
     <Button
       variant="outlined"
-      className={`${small && '!text-small'} h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold !leading-4`}
+      className={`${small && '!text-small'} h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/OutlinedButton.tsx
+++ b/src/components/Button/OutlinedButton.tsx
@@ -15,9 +15,9 @@ const OutlinedButton = ({ children, onClick, disabled, type, small, startIcon, e
   return (
     <Button
       variant="outlined"
-      className={`${small && '!text-small'} ${
-        !disabled && '!border-pointBlue'
-      } h-fit !rounded-sm !py-2 !px-6 !font-semibold`}
+      className={`${
+        small && '!text-small'
+      }  h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold disabled:!border-subGray`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/OutlinedButton.tsx
+++ b/src/components/Button/OutlinedButton.tsx
@@ -17,7 +17,7 @@ const OutlinedButton = ({ children, onClick, disabled, type, small, startIcon, e
       variant="outlined"
       className={`${
         small && '!text-small'
-      }  h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold disabled:!border-subGray`}
+      } h-fit !rounded-sm !border-pointBlue !py-2 !px-6 !font-semibold disabled:!border-subGray`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -15,7 +15,7 @@ const TextButton = ({ children, onClick, disabled, type, small }: TextButtonProp
       variant="text"
       className={`${
         small && '!text-small'
-      } h-fit !rounded-sm !py-2 !px-6 !font-semibold !leading-4 hover:!bg-pointBlue/10 active:!bg-pointBlue/30`}
+      } h-fit !rounded-sm !py-2 !px-6 !font-semibold hover:!bg-pointBlue/10 active:!bg-pointBlue/30`}
       type={type}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -15,7 +15,7 @@ const TextButton = ({ children, onClick, disabled, type, small }: TextButtonProp
       variant="text"
       className={`${
         small && '!text-small'
-      } h-fit !rounded-sm !py-2 !px-6 !font-semibold hover:!bg-pointBlue/10 active:!bg-pointBlue/30`}
+      } h-fit !rounded-sm !py-2 !px-6 !font-semibold hover:!bg-pointBlue/10 active:!bg-pointBlue/30 disabled:!text-subGray`}
       type={type}
       onClick={onClick}
       disabled={disabled}


### PR DESCRIPTION
## 연관 이슈
- close #397
- 선행 풀리퀘 #398입니당

## 작업 요약
- outlineButton disable시 border색 pointColor 적용되는거 제거했씁니다

## Preview 이미지
- 일단 outlineButton에 border색만 바꿨는데, 다른 버튼의 disable은 mui 기본 디자인거 그대로 입니다! 
이대로 나쁘지 않을 것 같아서 다 냅뒀습니다!
![image](https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/70d06efd-e3ae-4c73-8b06-739a675aee94)
2023.06.30) 추가 -> props diabled로 판별하는게 아닌, tailwind css상에서 disabled속성으로 바꿨습니다!
그리고 원래는 outlinedButton만 색 바꿔줬는데, text, filled 다 subGray색으로 변경했습니다! 아래가 바뀐 버튼입니다
![image](https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/17c95137-2b2b-4588-a6cd-9dc180fd79a2)
