### PR TITLE
Feature/게임페이지 UI 구현 #401

### DIFF
--- a/src/pages/Game/Game.tsx
+++ b/src/pages/Game/Game.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Divider, Stack, Typography } from '@mui/material';
+import StandardTab from '@components/Tab/StandardTab';
+import OutlinedButton from '@components/Button/OutlinedButton';
+
+const Game = () => {
+  const [tab, setTab] = useState(0);
+
+  const point = 29472; // TODO API 받아오기
+  const todayTotalGamePoint = 1214; // TODO API 받아오기
+  const gameList = [{ id: 1, label: 'BASEBALL' }];
+
+  return (
+    <Stack>
+      <Stack direction="row" justifyContent="space-between" className="mb-5">
+        <StandardTab options={gameList} tab={tab} setTab={setTab} />
+        <OutlinedButton>게임 규칙</OutlinedButton>
+      </Stack>
+      <Stack direction="row" justifyContent="flex-end">
+        <>
+          <Typography marginRight={0.5}>보유포인트 :</Typography>
+          <Typography fontWeight="bold">{point}</Typography>
+        </>
+        <Divider className="bg-white" sx={{ marginX: 1, marginY: 0.5 }} orientation="vertical" flexItem />
+        <>
+          <Typography marginRight={0.5}>오늘 결과 :</Typography>
+          <Typography fontWeight="bold" className={todayTotalGamePoint >= 0 ? 'text-pointBlue' : 'text-subRed'}>
+            {todayTotalGamePoint}
+          </Typography>
+        </>
+      </Stack>
+      {/* TODO 게임 불러오기 */}
+    </Stack>
+  );
+};
+
+export default Game;

--- a/src/pages/Game/Game.tsx
+++ b/src/pages/Game/Game.tsx
@@ -19,12 +19,12 @@ const Game = () => {
       <Stack direction="row" justifyContent="flex-end">
         <>
           <Typography marginRight={0.5}>보유포인트 :</Typography>
-          <Typography fontWeight="bold">{point}</Typography>
+          <Typography className="!font-semibold">{point}</Typography>
         </>
         <Divider className="bg-white" sx={{ marginX: 1, marginY: 0.5 }} orientation="vertical" flexItem />
         <>
           <Typography marginRight={0.5}>오늘 결과 :</Typography>
-          <Typography fontWeight="bold" className={todayTotalGamePoint >= 0 ? 'text-pointBlue' : 'text-subRed'}>
+          <Typography className={`!font-semibold ${todayTotalGamePoint >= 0 ? 'text-pointBlue' : 'text-subRed'}`}>
             {todayTotalGamePoint}
           </Typography>
         </>

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -12,6 +12,7 @@ import FitContainer from '@components/Layout/Container/FitContainer';
 import BoardList from '@pages/board/BoardList';
 import SignUp from '@pages/SignUp/SignUp';
 import Login from '@pages/login/Login';
+import Game from '@pages/Game/Game';
 
 const useMainRouter = () =>
   useRoutes([
@@ -64,6 +65,10 @@ const useMainRouter = () =>
             {
               path: 'study',
               element: <Study />,
+            },
+            {
+              path: 'game',
+              element: <Game />,
             },
           ],
         },


### PR DESCRIPTION
## 연관 이슈
- Close #401

## 작업 요약
- 게임 페이지 탭, 게임 규칙 버튼, 포인트 정보 부분 UI 구성하였습니다.

## 작업 상세 설명
- 게임 페이지 라우터에 추가해주었습니다.
- point의 경우 추후 API 받아와서 띄워줄 예정이라 현재는 임시 숫자로 넣어주었습니다.
- 실제 게임화면의 경우 별도 프로젝트에서 들고와 띄워줄 거라서 해당 PR에는 화면이 포함되어 있지 않습니다.

## 리뷰 요구사항
- 예상 리뷰 소요 시간 7분

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/89ec52cd-2b0e-410b-9363-b46f3ce8048a">
