### PR TITLE
Feature/헤더 로그인 전 로그인 버튼 띄워주기 #269

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -3,10 +3,12 @@ import { Link } from 'react-router-dom';
 import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { VscGithubInverted, VscAccount } from 'react-icons/vsc';
+import FilledButton from '@components/Button/FilledButton';
 import AccountMenu from './Menu/AccountMenu';
 
 const Header = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const userInfo = null; // TODO 로그인 정보 받아와서 set 해줘야할 듯
   const open = Boolean(anchorEl);
 
   const handleAccountIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -26,17 +28,21 @@ const Header = () => {
         <Link to="/">
           <Logo className="h-8" />
         </Link>
-        <div>
-          <IconButton target="_blank" href="https://keeper.or.kr/wiki/%EB%8C%80%EB%AC%B8">
-            <Typography className="h-6 w-6 rounded-full bg-pointBlue text-mainBlack">W</Typography>
-          </IconButton>
-          <IconButton target="_blank" href="https://github.com/KEEPER31337">
-            <VscGithubInverted fill="#4CEEF9" />
-          </IconButton>
-          <IconButton onClick={handleAccountIconClick}>
-            <VscAccount fill="#4CEEF9" />
-          </IconButton>
-        </div>
+        {userInfo ? (
+          <div>
+            <IconButton target="_blank" href="https://keeper.or.kr/wiki/%EB%8C%80%EB%AC%B8">
+              <Typography className="h-6 w-6 rounded-full bg-pointBlue text-mainBlack">W</Typography>
+            </IconButton>
+            <IconButton target="_blank" href="https://github.com/KEEPER31337">
+              <VscGithubInverted fill="#4CEEF9" />
+            </IconButton>
+            <IconButton onClick={handleAccountIconClick}>
+              <VscAccount fill="#4CEEF9" />
+            </IconButton>
+          </div>
+        ) : (
+          <FilledButton>LOGIN</FilledButton>
+        )}
       </Toolbar>
       <AccountMenu anchorEl={anchorEl} open={open} onClose={handleMenuClose} />
     </AppBar>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -41,7 +41,9 @@ const Header = () => {
             </IconButton>
           </div>
         ) : (
-          <FilledButton>LOGIN</FilledButton>
+          <Link to="/login">
+            <FilledButton>LOGIN</FilledButton>
+          </Link>
         )}
       </Toolbar>
       <AccountMenu anchorEl={anchorEl} open={open} onClose={handleMenuClose} />


### PR DESCRIPTION
## 연관 이슈
- Close #269

## 작업 요약
- 헤더에 로그인 페이지로 갈 수 있는 버튼 추가하였습니다.

## 작업 상세 설명
- 로그인 후 프로필 아이콘에 유저 프로필 띄워줄 거라 userInfo가 없을 때 로그인 버튼을 띄워주는 식으로 구현하였습니다.
- 버튼 클릭시 로그인 페이지로 이동하는 기능도 작동 확인하였습니다.

## 리뷰 요구사항
- 예상 소요시간 5분

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/e02f5404-6d21-4ff1-8826-4d56a904e9e0">
