### PR TITLE
Feature/사이드바 라우터 연결 #271

### DIFF
--- a/src/components/Navigation/SubCategoryNav.tsx
+++ b/src/components/Navigation/SubCategoryNav.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { CategoryMenu } from '@constants/category';
 import { ListItemButton, ListItemText } from '@mui/material';
 
@@ -8,7 +9,7 @@ interface SubCategoryNavProps {
 
 const SubCategoryNav = ({ subcategory }: SubCategoryNavProps) => {
   return (
-    <ListItemButton className="w-full">
+    <ListItemButton component={Link} to={`/${subcategory.path}`} className="w-full">
       <ListItemText primary={`• ${subcategory.name}`} />
     </ListItemButton>
   );

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,6 +1,7 @@
 export interface CategoryMenu {
   id: number;
   name: string;
+  path?: string;
 }
 export interface Category extends CategoryMenu {
   subCategories: CategoryMenu[];
@@ -14,30 +15,37 @@ const CATEGORIES: Category[] = [
       {
         id: 101,
         name: '공지사항',
+        path: '#',
       },
       {
         id: 102,
         name: '건의사항',
+        path: '#',
       },
       {
         id: 103,
         name: '정보게시판',
+        path: '#',
       },
       {
         id: 104,
         name: '자유게시판',
+        path: '#',
       },
       {
         id: 105,
         name: '익명게시판',
+        path: '#',
       },
       {
         id: 106,
         name: '졸업생게시판',
+        path: '#',
       },
       {
         id: 107,
         name: '시험게시판',
+        path: '#',
       },
     ],
   },
@@ -48,18 +56,22 @@ const CATEGORIES: Category[] = [
       {
         id: 201,
         name: '스터디',
+        path: 'study',
       },
       {
         id: 202,
         name: '발표자료',
+        path: '#',
       },
       {
         id: 203,
         name: '기술문서',
+        path: '#',
       },
       {
         id: 204,
         name: '회계부',
+        path: '#',
       },
     ],
   },
@@ -70,10 +82,12 @@ const CATEGORIES: Category[] = [
       {
         id: 301,
         name: '도서',
+        path: '#',
       },
       {
         id: 302,
         name: '기자재',
+        path: '#',
       },
     ],
   },
@@ -84,14 +98,17 @@ const CATEGORIES: Category[] = [
       {
         id: 401,
         name: '세미나 출석',
+        path: 'seminar',
       },
       {
         id: 402,
         name: '활동인원조사',
+        path: '#',
       },
       {
         id: 403,
         name: '임원진 선거',
+        path: '#',
       },
     ],
   },
@@ -102,10 +119,12 @@ const CATEGORIES: Category[] = [
       {
         id: 501,
         name: '랭킹',
+        path: '#',
       },
       {
         id: 502,
         name: '게임',
+        path: '#',
       },
     ],
   },
@@ -116,30 +135,37 @@ const CATEGORIES: Category[] = [
       {
         id: 601,
         name: 'CTF',
+        path: '#',
       },
       {
         id: 602,
         name: 'CHALLENGES',
+        path: '#',
       },
       {
         id: 603,
         name: 'SCOREBOARD',
+        path: '#',
       },
       {
         id: 604,
         name: 'TEAM',
+        path: '#',
       },
       {
         id: 605,
         name: '문제관리',
+        path: '#',
       },
       {
         id: 606,
         name: '제출로그',
+        path: '#',
       },
       {
         id: 607,
         name: '대회운영',
+        path: '#',
       },
     ],
   },
@@ -150,30 +176,37 @@ const CATEGORIES: Category[] = [
       {
         id: 701,
         name: '직책관리',
+        path: '#',
       },
       {
         id: 702,
         name: '선거관리',
+        path: '#',
       },
       {
         id: 703,
         name: '도서관리',
+        path: 'admin/libraryManage',
       },
       {
         id: 704,
         name: '기자재관리',
+        path: '#',
       },
       {
         id: 705,
         name: '세미나관리',
+        path: 'admin/seminarManage',
       },
       {
         id: 706,
         name: '활동인원관리',
+        path: '#',
       },
       {
         id: 707,
         name: '상벌점관리',
+        path: '#',
       },
     ],
   },


### PR DESCRIPTION
## 연관 이슈
- Close #271

## 작업 요약
- 사이드바 항목 클릭하면 카테고리 path로 지정된 경로로 이동되도록 처리하였습니다.

## 작업 상세 설명
- router에 넣지 않은 경로들은 임시로 `#`으로 경로 지정해주었고, router에 들어간 경로는 바로 적어주었습니다.
- 클릭시 경로 이동되는 것 확인하였습니다.
- 현재는 useMainRouter에 라우터로 넣어주는 것과 별도로 category에 경로 추가해줘야 이동이 되는데 나중에 한 번에 처리되도록 확장시킬 예정입니다. #406

## 리뷰 요구사항
- 예상 소요 시간 `3분`
