### PR TITLE
Feature/사이드바 현재 페이지 하이라이팅 #272

### DIFF
--- a/src/components/Navigation/CategoryNav.tsx
+++ b/src/components/Navigation/CategoryNav.tsx
@@ -13,6 +13,7 @@ const CategoryNav = ({ category }: CategoryNavProps) => {
   return (
     <ListItem className="flex flex-col" disablePadding>
       <ListItemButton
+        selected={open}
         className="w-full"
         onClick={() => {
           setOpen((prev) => !prev);

--- a/src/components/Navigation/SubCategoryNav.tsx
+++ b/src/components/Navigation/SubCategoryNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, matchPath, useLocation } from 'react-router-dom';
 import { CategoryMenu } from '@constants/category';
 import { ListItemButton, ListItemText } from '@mui/material';
 
@@ -8,9 +8,12 @@ interface SubCategoryNavProps {
 }
 
 const SubCategoryNav = ({ subcategory }: SubCategoryNavProps) => {
+  const currentPath = useLocation();
+  const isCurrentPath = Boolean(matchPath(currentPath.pathname, `/${subcategory.path}`));
+
   return (
     <ListItemButton component={Link} to={`/${subcategory.path}`} className="w-full">
-      <ListItemText primary={`• ${subcategory.name}`} />
+      <ListItemText className={isCurrentPath ? 'text-pointBlue' : ''} primary={`• ${subcategory.name}`} />
     </ListItemButton>
   );
 };


### PR DESCRIPTION
## 연관 이슈
- #272 

## 작업 요약
- 사이드바 상위 카테고리 클릭시 열림 여부에 따라 background 색 처리되도록 하였고, 현재 경로 카테고리의 경우 text 색 처리 해주었습니다.

## 작업 상세 설명
- `selected`된 카테고리 항목에는 자동으로 하이라이트 처리되고, 현재 경로와의 비교는 `react-router-dom`에서 제공하는 `useLocation`을 통해 현재 경로를 받아와서 `matchPath` 함수를 통해 같은 경로인 지 비교해주었습니다.
- 상위 카테고리 새로 고침 시 현재 경로 카테고리를 포함한 카테고리가 기본적으로 열리면 좋을 것 같은데 현재 PR에서는 적용 안 된 상태입니다. 상위 카테고리에 대한 경로를 추가하여(다른 좋은 방법있으면 의견 부탁드립니다!)  작업하는 것 이슈 새로 파서 반영해보겠습니다. #408

## 리뷰 요구사항
- 선행 PR입니다. #407 PR 먼저 리뷰 부탁드립니다!
- 이 PR은 [feat : 카테고리 열렸을 때 색 들어가도록 선택 여부 지정](https://github.com/KEEPER31337/Homepage-Front-R2/commit/c34913a87238243246c013b40282a558aa19c0ed) 커밋 부터 확인하면 됩니다!
- 예상 소요 시간 `7분`

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/8bb16a80-8fa2-4ad6-aa72-aa18d5272bc3">
