### PR TITLE
Feature/인증 메일 모달 버튼 클릭 이벤트 핸들러 props로 받아오기 #434

### DIFF
--- a/src/components/Modal/MailAuthenticationModal.tsx
+++ b/src/components/Modal/MailAuthenticationModal.tsx
@@ -6,9 +6,16 @@ import ConfirmModal from './ConfirmModal';
 interface MailAuthenticationModalProps {
   open: boolean;
   onClose: () => void;
+  onOtherEmailButtonClick: () => void;
+  onResendMailButtonClick: () => void;
 }
 
-const MailAuthenticationModal = ({ open, onClose }: MailAuthenticationModalProps) => {
+const MailAuthenticationModal = ({
+  open,
+  onClose,
+  onOtherEmailButtonClick,
+  onResendMailButtonClick,
+}: MailAuthenticationModalProps) => {
   const modalContents =
     '이메일 주소가 정확한지 확인해 주세요.\n메일 서비스에 따라 인증 메일 발송이 늦어질 수 있습니다.';
 
@@ -16,8 +23,8 @@ const MailAuthenticationModal = ({ open, onClose }: MailAuthenticationModalProps
     <ConfirmModal open={open} onClose={onClose} title="인증 메일이 오지 않았나요?">
       <Typography className="h-24 w-[440px] whitespace-pre">{modalContents}</Typography>
       <Stack className="flex justify-end space-x-2" direction="row">
-        <OutlinedButton>다른 이메일로 인증</OutlinedButton>
-        <OutlinedButton>인증 메일 재발송</OutlinedButton>
+        <OutlinedButton onClick={onOtherEmailButtonClick}>다른 이메일로 인증</OutlinedButton>
+        <OutlinedButton onClick={onResendMailButtonClick}>인증 메일 재발송</OutlinedButton>
       </Stack>
     </ConfirmModal>
   );


### PR DESCRIPTION
## 연관 이슈
- Close #434

## 작업 요약
- `다른 이메일로 인증` 버튼 클릭 이벤트 props로 받아오도록 처리
- `인증 메일 재발송` 버튼 클릭 이벤트 props로 받아오도록 처리

## 작업 상세 설명
- 회원가입과 로그인에 공통적으로 사용되는 인증 메일 모달의 각 버튼을 사용되는 곳에서 서로 다르게 처리할 수 있도록 props로 이벤트 핸들러 받아올 수 있도록 해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 `1분`
- 네이밍 괜찮은 지 한 번 봐주세요!