### PR TITLE
Feature/게시글 설정 및 업로드 모달 기능 #469

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -90,3 +90,17 @@ export interface CommentInfo {
   likeCount: number;
   dislikeCount: number;
 }
+
+export interface UploadPostSettings {
+  isNotice?: boolean;
+  isSecret?: boolean;
+  isTemp?: boolean;
+  allowComment?: boolean;
+  password?: string;
+}
+
+export interface UploadPost extends UploadPostSettings {
+  title: string;
+  content: string;
+  categoryId: string;
+}

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -6,11 +6,13 @@ import StandardInput from '@components/Input/StandardInput';
 import StandardEditor from '@components/Editor/StandardEditor';
 import FileUploader from '@components/Uploader/FileUploader';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import { UploadPostSettings } from '@api/dto';
 import SettingUploadModal from './Modal/SettingUploadModal';
 
 const BoardWrite = () => {
   const boardName = '자유게시판'; // TODO 게시판 이름 불러오기
   const editorRef = useRef<Editor>();
+  const [postSettingInfo, setPostSettingInfo] = useState<UploadPostSettings | null>(null);
   const [settingModalOpen, setSettingModalOpen] = useState(false);
 
   const handleCompleteButtonClick = () => {
@@ -49,7 +51,12 @@ const BoardWrite = () => {
         <OutlinedButton>임시저장</OutlinedButton>
         <OutlinedButton onClick={handleCompleteButtonClick}>작성완료</OutlinedButton>
       </div>
-      <SettingUploadModal open={settingModalOpen} onClose={handleSettingModalClose} />
+      <SettingUploadModal
+        open={settingModalOpen}
+        onClose={handleSettingModalClose}
+        postSettingInfo={postSettingInfo}
+        setPostSettingInfo={setPostSettingInfo}
+      />
     </div>
   );
 };

--- a/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
@@ -21,10 +21,10 @@ const SettingUploadModal = ({ open, onClose, postSettingInfo, setPostSettingInfo
 
   const handleCheckBoxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;
-    setPostSettingInfo({
-      ...postSettingInfo,
+    setPostSettingInfo((prev) => ({
+      ...prev,
       [name]: checked,
-    });
+    }));
   };
 
   return (

--- a/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
@@ -3,17 +3,28 @@ import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
 import StandardInput from '@components/Input/StandardInput';
 import ActionModal from '@components/Modal/ActionModal';
 import ImageUploader from '@components/Uploader/ImageUploader';
+import { UploadPostSettings } from '@api/dto';
 
 interface SettingUploadModalProps {
   open: boolean;
   onClose: () => void;
+  postSettingInfo: UploadPostSettings | null;
+  setPostSettingInfo: React.Dispatch<React.SetStateAction<UploadPostSettings | null>>;
 }
 
-const SettingUploadModal = ({ open, onClose }: SettingUploadModalProps) => {
+const SettingUploadModal = ({ open, onClose, postSettingInfo, setPostSettingInfo }: SettingUploadModalProps) => {
   const [, setThumbnail] = useState<Blob>();
 
   const handleActionButonClick = () => {
     // TODO
+  };
+
+  const handleCheckBoxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    setPostSettingInfo({
+      ...postSettingInfo,
+      [name]: checked,
+    });
   };
 
   return (
@@ -29,20 +40,40 @@ const SettingUploadModal = ({ open, onClose }: SettingUploadModalProps) => {
       </div>
       <FormGroup>
         <span>
-          <FormControlLabel control={<Checkbox />} label="공지" />
-          <FormControlLabel control={<Checkbox />} label="댓글 허용" />
+          <FormControlLabel
+            control={
+              <Checkbox checked={Boolean(postSettingInfo?.isNotice)} name="isNotice" onChange={handleCheckBoxChange} />
+            }
+            label="공지"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(postSettingInfo?.allowComment)}
+                name="allowComment"
+                onChange={handleCheckBoxChange}
+              />
+            }
+            label="댓글 허용"
+          />
         </span>
         <span className="flex items-center">
-          <FormControlLabel control={<Checkbox />} label="비밀글" />
-          {/* TODO 비밀글 체크 시에만 렌더링 되도록 처리 */}
-          <StandardInput
-            value=""
-            type="password"
-            placeholder="게시글 비밀번호"
-            onChange={() => {
-              // TODO
-            }}
+          <FormControlLabel
+            control={
+              <Checkbox checked={Boolean(postSettingInfo?.isSecret)} name="isSecret" onChange={handleCheckBoxChange} />
+            }
+            label="비밀글"
           />
+          {postSettingInfo?.isSecret && (
+            <StandardInput
+              value=""
+              type="password"
+              placeholder="게시글 비밀번호"
+              onChange={() => {
+                // TODO
+              }}
+            />
+          )}
         </span>
       </FormGroup>
     </ActionModal>


### PR DESCRIPTION
## 연관 이슈
- Close #469

## 작업 요약
- 게시글 작성 페이지 설정 및 업로드 모달 체크 박스 이벤트 핸들러로 처리해주었습니다.

## 작업 상세 설명
- 게시글 생성 api 호출은 상위 컴포넌트에서 처리할 거라 props로 `postSettingInfo`, `setPostSettingInfo` 받아와서 처리해주었습니다.
- `postSettingInfo` 타입 `null`도 가능하도록 해주었는데 api에서 null로 보내주면 default 값으로 설정해줘서 따로 체크박스 건드리지 않으면 `null` 상태로 보내도 괜찮을 테니 이렇게 처리해주었습니다.
- 각 체크박스는 하나의 핸들러로 다룰 수 있도록 해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 `3분`
