### PR TITLE
Feature/게시글 조회 게시글 내용 UI #439

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -115,6 +115,7 @@ export interface PostInfo {
   categoryName: string;
   title: string;
   writerName: string;
+  writerThumbnailPath: string | null;
   visitCount: number;
   thumbnailPath: string;
   content: string;

--- a/src/components/Viewer/StandardViewer.tsx
+++ b/src/components/Viewer/StandardViewer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import '@toast-ui/editor/dist/toastui-editor-viewer.css';
+import { Viewer } from '@toast-ui/react-editor';
+
+interface StandardViewerProps {
+  content: string;
+  className?: string;
+}
+
+const StandardViewer = ({ content, className }: StandardViewerProps) => {
+  return (
+    <div className={className}>
+      <Viewer initialValue={content} theme="dark" />
+    </div>
+  );
+};
+
+export default StandardViewer;

--- a/src/mocks/postApi.ts
+++ b/src/mocks/postApi.ts
@@ -4,13 +4,22 @@ const post: PostInfo = {
   categoryName: '카테고리 이름',
   title: '게시글 제목',
   writerName: 'UmbEizQdxY',
+  writerThumbnailPath: null,
   visitCount: 1,
   thumbnailPath: 'keeper_files/thumbnail/2023-07-10/46683d42-5b7d-4eb7-a52e-249684557551.jpeg',
-  content: '게시글 내용',
+  content: '게시글 내용게시글 내용게시글 내용게시글 내용게시글 내용게시글 내용',
   files: [
     {
       id: 88,
       name: 'testImage_1x1.png',
+      path: 'keeper_files/files/2023-07-10/8d91f421-0519-426a-83ce-fcb25c094fc5.png',
+      size: 95,
+      ipAddress: '127.0.0.1',
+      uploadTime: '2023-07-10 10:48:23',
+    },
+    {
+      id: 89,
+      name: '2.txt',
       path: 'keeper_files/files/2023-07-10/8d91f421-0519-426a-83ce-fcb25c094fc5.png',
       size: 95,
       ipAddress: '127.0.0.1',

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -9,7 +9,7 @@ const BoardView = () => {
   const postInfo = post; // TODO API 적용
 
   return (
-    <div className="-mt-16 space-y-16">
+    <div className="-mt-16 space-y-12">
       <div className="space-y-2">
         <BannerSection />
         <PostSection />

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -10,7 +10,7 @@ const BoardView = () => {
 
   return (
     <div className="-mt-16 space-y-16">
-      <div>
+      <div className="space-y-2">
         <BannerSection />
         <PostSection />
       </div>

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -2,12 +2,18 @@ import React from 'react';
 import post from '@mocks/postApi';
 import CommentSection from './Section/CommentSection';
 import AdjacentPostNavSection from './Section/AdjacentPostNavSection';
+import PostSection from './Section/PostSection';
+import BannerSection from './Section/BannerSection';
 
 const BoardView = () => {
   const postInfo = post; // TODO API 적용
 
   return (
-    <div className="space-y-16">
+    <div className="-mt-16 space-y-16">
+      <div>
+        <BannerSection />
+        <PostSection />
+      </div>
       <AdjacentPostNavSection adjacentPosts={postInfo.adjacentPosts} />
       <CommentSection />
     </div>

--- a/src/pages/board/BoardView/Section/BannerSection.tsx
+++ b/src/pages/board/BoardView/Section/BannerSection.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Chip, Typography } from '@mui/material';
+import OutlinedButton from '@components/Button/OutlinedButton';
+
+const BannerSection = () => {
+  return (
+    <div className="relative bg-mainBlack px-6 py-6">
+      <img
+        src="https://avatars.githubusercontent.com/u/78250089?v=4"
+        alt="post thumbnail"
+        className="absolute inset-0 h-full w-full object-cover opacity-10"
+      />
+      <div className="mx-auto mt-10 max-w-xl text-center">
+        <Chip className="mb-4 !rounded-md !bg-pointBlue/50" label="자유게시판" />
+        <Typography variant="h3" className="flex h-12 items-center justify-center !font-semibold">
+          게시글 제목입니다.
+        </Typography>
+        <p className="text-small leading-8 text-gray-300">작성자-작성시간-조회수</p>
+      </div>
+      <div className="flex justify-end space-x-2">
+        <OutlinedButton>글 수정</OutlinedButton>
+        <OutlinedButton>글 삭제</OutlinedButton>
+      </div>
+    </div>
+  );
+};
+
+export default BannerSection;

--- a/src/pages/board/BoardView/Section/BannerSection.tsx
+++ b/src/pages/board/BoardView/Section/BannerSection.tsx
@@ -4,7 +4,7 @@ import OutlinedButton from '@components/Button/OutlinedButton';
 
 const BannerSection = () => {
   return (
-    <div className="relative bg-mainBlack px-6 py-6">
+    <div className="relative bg-mainBlack px-6 py-2">
       <img
         src="https://avatars.githubusercontent.com/u/78250089?v=4"
         alt="post thumbnail"

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -7,8 +7,8 @@ import { VscArrowDown, VscArrowUp, VscFile } from 'react-icons/vsc';
 
 const PostSection = () => {
   return (
-    <div className="min-h-[500px] bg-middleBlack px-14 py-10">
-      <StandardViewer className="min-h-[310px]" content={post.content} />
+    <div className="min-h-[520px] bg-middleBlack px-14 py-10">
+      <StandardViewer className="min-h-[330px]" content={post.content} />
       <div className="mb-10 mt-2 flex justify-end gap-3 text-pointBlue">
         {post.files.map((file) => (
           <div key={file.id} className="flex">

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -1,7 +1,34 @@
 import React from 'react';
+import StandardViewer from '@components/Viewer/StandardViewer';
+import post from '@mocks/postApi';
+import FilledButton from '@components/Button/FilledButton';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import { VscArrowDown, VscArrowUp, VscFile } from 'react-icons/vsc';
 
 const PostSection = () => {
-  return <div />;
+  return (
+    <div className="min-h-[500px] bg-middleBlack px-14 py-10">
+      <StandardViewer className="min-h-[310px]" content={post.content} />
+      <div className="mb-10 mt-2 flex justify-end gap-3 text-pointBlue">
+        {post.files.map((file) => (
+          <div key={file.id} className="flex">
+            <VscFile className="mr-1" size={24} />
+            <span>{file.name}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-center space-x-2">
+        <FilledButton small>
+          <VscArrowUp className="mr-1" size={10} />
+          <span>추천 (5)</span>
+        </FilledButton>
+        <OutlinedButton small>
+          <VscArrowDown className="mr-1" size={10} />
+          <span>비추천 (5)</span>
+        </OutlinedButton>
+      </div>
+    </div>
+  );
 };
 
 export default PostSection;

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PostSection = () => {
+  return <div />;
+};
+
+export default PostSection;


### PR DESCRIPTION
## 연관 이슈
- Close #439 

## 작업 요약
- 게시글 조회 게시글 내용 UI 구성

## 작업 상세 설명
- Banner 섹션 - 썸네일이 배너로 들어가고, 게시글 정보 및 글 수정/삭제 버튼 있는 섹션
- Post 섹션 - 게시글 내용, 파일, 추천/비추천 버튼 있는 섹션

## 리뷰 요구사항
- 예상 소요시간 `5분`
- 급하게 하느라 중간중간에 변수로 안 두고 임시로 하드 코딩 해둔 텍스트들 몇몇 있는데 기능 구현하면서 처리해보겠습니다!
- 배너섹션 작성자, 작성시간, 조회수 부분도 기능 구현하면서 UI 좀 더 다듬어 올리겠습니다!

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/c97f6573-19c9-49af-88c0-cda151b24f37">
