### PR TITLE
Feature/게시글 작성 api 연동 #431

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -102,5 +102,5 @@ export interface UploadPostSettings {
 export interface UploadPost extends UploadPostSettings {
   title: string;
   content: string;
-  categoryId: string;
+  categoryId: number;
 }

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -92,10 +92,10 @@ export interface CommentInfo {
 }
 
 export interface UploadPostSettings {
-  isNotice?: boolean;
-  isSecret?: boolean;
-  isTemp?: boolean;
-  allowComment?: boolean;
+  isNotice: boolean;
+  isSecret: boolean;
+  isTemp: boolean;
+  allowComment: boolean;
   password?: string;
 }
 

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -3,7 +3,16 @@ import { useMutation } from 'react-query';
 import { UploadPost } from './dto';
 
 const useUploadPostMutation = () => {
-  const fetcher = (postInfo: UploadPost) => axios.post('/posts', postInfo);
+  const fetcher = (postInfo: UploadPost) => {
+    const formData = new FormData();
+    formData.append('request', new Blob([JSON.stringify(postInfo)], { type: 'application/json' }));
+
+    return axios.post('/posts', formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
+    });
+  };
 
   return useMutation(fetcher);
 };

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+import { UploadPost } from './dto';
+
+const useUploadPostMutation = () => {
+  const fetcher = (postInfo: UploadPost) => axios.post('/posts', postInfo);
+
+  return useMutation(fetcher);
+};
+
+export default useUploadPostMutation;

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -8,6 +8,7 @@ import FileUploader from '@components/Uploader/FileUploader';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import useUploadPostMutation from '@api/postApi';
 import { UploadPostSettings } from '@api/dto';
+import { useNavigate } from 'react-router-dom';
 import SettingUploadModal from './Modal/SettingUploadModal';
 
 const BoardWrite = () => {
@@ -24,6 +25,7 @@ const BoardWrite = () => {
   const [settingModalOpen, setSettingModalOpen] = useState(false);
 
   const editorRef = useRef<Editor>();
+  const navigate = useNavigate();
   const { mutate: uploadPostMutation } = useUploadPostMutation();
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +37,14 @@ const BoardWrite = () => {
 
     // TODO 필수값 처리
     // TODO isTemp 여부에 따라 content 옵셔널 처리, 업로드 이후 동작 처리
-    uploadPostMutation({ categoryId, title: postTitle, content, ...postSettingInfo });
+    uploadPostMutation(
+      { categoryId, title: postTitle, content, ...postSettingInfo },
+      {
+        onSuccess: () => {
+          navigate('/board/list');
+        },
+      },
+    );
   };
 
   const handleSaveButtonClick = ({ isTemp }: { isTemp: boolean }) => {

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -12,10 +12,15 @@ import SettingUploadModal from './Modal/SettingUploadModal';
 
 const BoardWrite = () => {
   const boardName = '자유게시판'; // TODO 게시판 이름 불러오기
-  const categoryId = 116; // TODO 게시판 ID 연결하기
+  const categoryId = 104; // TODO 게시판 ID 연결하기
 
   const [postTitle, setPostTitle] = useState('');
-  const [postSettingInfo, setPostSettingInfo] = useState<UploadPostSettings | null>(null);
+  const [postSettingInfo, setPostSettingInfo] = useState<UploadPostSettings>({
+    isNotice: false,
+    isSecret: false,
+    isTemp: false,
+    allowComment: false,
+  });
   const [settingModalOpen, setSettingModalOpen] = useState(false);
 
   const editorRef = useRef<Editor>();

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -15,8 +15,16 @@ const BoardWrite = () => {
   const [postSettingInfo, setPostSettingInfo] = useState<UploadPostSettings | null>(null);
   const [settingModalOpen, setSettingModalOpen] = useState(false);
 
-  const handleCompleteButtonClick = () => {
+  const handleUploadButonClick = () => {
+    // TODO
+  };
+
+  const handleSaveButtonClick = ({ isTemp }: { isTemp: boolean }) => {
     setSettingModalOpen(true);
+    setPostSettingInfo((prev) => ({
+      ...prev,
+      isTemp,
+    }));
   };
 
   const handleSettingModalClose = () => {
@@ -48,12 +56,13 @@ const BoardWrite = () => {
         <FileUploader />
       </div>
       <div className="flex justify-end space-x-2">
-        <OutlinedButton>임시저장</OutlinedButton>
-        <OutlinedButton onClick={handleCompleteButtonClick}>작성완료</OutlinedButton>
+        <OutlinedButton onClick={() => handleSaveButtonClick({ isTemp: true })}>임시저장</OutlinedButton>
+        <OutlinedButton onClick={() => handleSaveButtonClick({ isTemp: false })}>작성완료</OutlinedButton>
       </div>
       <SettingUploadModal
         open={settingModalOpen}
         onClose={handleSettingModalClose}
+        onUploadButonClick={handleUploadButonClick}
         postSettingInfo={postSettingInfo}
         setPostSettingInfo={setPostSettingInfo}
       />

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -6,17 +6,30 @@ import StandardInput from '@components/Input/StandardInput';
 import StandardEditor from '@components/Editor/StandardEditor';
 import FileUploader from '@components/Uploader/FileUploader';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import useUploadPostMutation from '@api/postApi';
 import { UploadPostSettings } from '@api/dto';
 import SettingUploadModal from './Modal/SettingUploadModal';
 
 const BoardWrite = () => {
   const boardName = '자유게시판'; // TODO 게시판 이름 불러오기
-  const editorRef = useRef<Editor>();
+  const categoryId = 116; // TODO 게시판 ID 연결하기
+
+  const [postTitle, setPostTitle] = useState('');
   const [postSettingInfo, setPostSettingInfo] = useState<UploadPostSettings | null>(null);
   const [settingModalOpen, setSettingModalOpen] = useState(false);
 
+  const editorRef = useRef<Editor>();
+  const { mutate: uploadPostMutation } = useUploadPostMutation();
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPostTitle(e.target.value);
+  };
+
   const handleUploadButonClick = () => {
-    // TODO
+    const content = editorRef.current?.getInstance().getMarkdown() || '';
+
+    // TODO isTemp 여부에 따라 content 옵셔널 처리, 업로드 이후 동작 처리
+    uploadPostMutation({ categoryId, title: postTitle, content, ...postSettingInfo });
   };
 
   const handleSaveButtonClick = ({ isTemp }: { isTemp: boolean }) => {
@@ -39,13 +52,7 @@ const BoardWrite = () => {
           <Typography fontWeight="semibold" className="!mr-2">
             제목
           </Typography>
-          <StandardInput
-            className="w-[498px]"
-            value=""
-            onChange={() => {
-              // TODO
-            }}
-          />
+          <StandardInput className="w-[498px]" value={postTitle} onChange={handleTitleChange} />
         </Stack>
       </div>
       <StandardEditor height="470px" forwardedRef={editorRef as React.MutableRefObject<Editor>} />

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -28,6 +28,7 @@ const BoardWrite = () => {
   const handleUploadButonClick = () => {
     const content = editorRef.current?.getInstance().getMarkdown() || '';
 
+    // TODO 필수값 처리
     // TODO isTemp 여부에 따라 content 옵셔널 처리, 업로드 이후 동작 처리
     uploadPostMutation({ categoryId, title: postTitle, content, ...postSettingInfo });
   };

--- a/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
@@ -8,16 +8,19 @@ import { UploadPostSettings } from '@api/dto';
 interface SettingUploadModalProps {
   open: boolean;
   onClose: () => void;
+  onUploadButonClick: () => void;
   postSettingInfo: UploadPostSettings | null;
   setPostSettingInfo: React.Dispatch<React.SetStateAction<UploadPostSettings | null>>;
 }
 
-const SettingUploadModal = ({ open, onClose, postSettingInfo, setPostSettingInfo }: SettingUploadModalProps) => {
+const SettingUploadModal = ({
+  open,
+  onClose,
+  onUploadButonClick,
+  postSettingInfo,
+  setPostSettingInfo,
+}: SettingUploadModalProps) => {
   const [, setThumbnail] = useState<Blob>();
-
-  const handleActionButonClick = () => {
-    // TODO
-  };
 
   const handleCheckBoxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;
@@ -31,9 +34,9 @@ const SettingUploadModal = ({ open, onClose, postSettingInfo, setPostSettingInfo
     <ActionModal
       open={open}
       onClose={onClose}
-      title="설정 확인 및 업로드"
-      actionButtonName="업로드"
-      onActionButonClick={handleActionButonClick}
+      title={`설정 확인 및 ${postSettingInfo?.isTemp ? '임시저장' : '업로드'}`}
+      actionButtonName={postSettingInfo?.isTemp ? '임시저장' : '업로드'}
+      onActionButonClick={onUploadButonClick}
     >
       <div className="mb-5 h-36">
         <ImageUploader isEdit={false} setThumbnail={setThumbnail} />

--- a/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
@@ -9,8 +9,8 @@ interface SettingUploadModalProps {
   open: boolean;
   onClose: () => void;
   onUploadButonClick: () => void;
-  postSettingInfo: UploadPostSettings | null;
-  setPostSettingInfo: React.Dispatch<React.SetStateAction<UploadPostSettings | null>>;
+  postSettingInfo: UploadPostSettings;
+  setPostSettingInfo: React.Dispatch<React.SetStateAction<UploadPostSettings>>;
 }
 
 const SettingUploadModal = ({
@@ -42,8 +42,8 @@ const SettingUploadModal = ({
     <ActionModal
       open={open}
       onClose={onClose}
-      title={`설정 확인 및 ${postSettingInfo?.isTemp ? '임시저장' : '업로드'}`}
-      actionButtonName={postSettingInfo?.isTemp ? '임시저장' : '업로드'}
+      title={`설정 확인 및 ${postSettingInfo.isTemp ? '임시저장' : '업로드'}`}
+      actionButtonName={postSettingInfo.isTemp ? '임시저장' : '업로드'}
       onActionButonClick={onUploadButonClick}
     >
       <div className="mb-5 h-36">
@@ -53,14 +53,14 @@ const SettingUploadModal = ({
         <span>
           <FormControlLabel
             control={
-              <Checkbox checked={Boolean(postSettingInfo?.isNotice)} name="isNotice" onChange={handleCheckBoxChange} />
+              <Checkbox checked={Boolean(postSettingInfo.isNotice)} name="isNotice" onChange={handleCheckBoxChange} />
             }
             label="공지"
           />
           <FormControlLabel
             control={
               <Checkbox
-                checked={Boolean(postSettingInfo?.allowComment)}
+                checked={Boolean(postSettingInfo.allowComment)}
                 name="allowComment"
                 onChange={handleCheckBoxChange}
               />
@@ -71,14 +71,14 @@ const SettingUploadModal = ({
         <span className="flex items-center">
           <FormControlLabel
             control={
-              <Checkbox checked={Boolean(postSettingInfo?.isSecret)} name="isSecret" onChange={handleCheckBoxChange} />
+              <Checkbox checked={Boolean(postSettingInfo.isSecret)} name="isSecret" onChange={handleCheckBoxChange} />
             }
             label="비밀글"
           />
-          {postSettingInfo?.isSecret && (
+          {postSettingInfo.isSecret && (
             <StandardInput
               name="password"
-              value={postSettingInfo?.password || ''}
+              value={postSettingInfo.password || ''}
               type="password"
               placeholder="게시글 비밀번호"
               onChange={handleSecretPasswordChange}

--- a/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/BoardWrite/Modal/SettingUploadModal.tsx
@@ -30,6 +30,14 @@ const SettingUploadModal = ({
     }));
   };
 
+  const handleSecretPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setPostSettingInfo((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
   return (
     <ActionModal
       open={open}
@@ -69,12 +77,11 @@ const SettingUploadModal = ({
           />
           {postSettingInfo?.isSecret && (
             <StandardInput
-              value=""
+              name="password"
+              value={postSettingInfo?.password || ''}
               type="password"
               placeholder="게시글 비밀번호"
-              onChange={() => {
-                // TODO
-              }}
+              onChange={handleSecretPasswordChange}
             />
           )}
         </span>

--- a/src/pages/board/BoardList.tsx
+++ b/src/pages/board/BoardList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TableViewSwitchButton from '@components/Button/TableViewSwitchButton';
 import StandardTable from '@components/Table/StandardTable';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import PageTitle from '@components/Typography/PageTitle';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import SearchSection from '@components/Section/SearchSection';
@@ -42,12 +42,17 @@ const dummyRow: BoardRow[] = [
 const BoardList = () => {
   const [searchParams] = useSearchParams();
   const category: string | null = searchParams.get('category');
+  const navigate = useNavigate();
+
+  const handleWriteButtonClick = () => {
+    navigate('/board/write');
+  };
 
   return (
     <div>
       <div className="flex justify-between">
         <PageTitle>{category}</PageTitle>
-        <OutlinedButton>글쓰기</OutlinedButton>
+        <OutlinedButton onClick={handleWriteButtonClick}>글쓰기</OutlinedButton>
       </div>
       <div className="flex items-center justify-between pb-5">
         <SearchSection />


### PR DESCRIPTION
## 연관 이슈
- Close #431 

## 작업 요약
- 게시글 작성 api 연동하였습니다.
- 게시글 작성 api request로 보낼 값들 입력값 반영되도록 기능 추가하였습니다.

## 작업 상세 설명
- 썸네일과 파일의 제외한 게시글 작성 정보들 api 연동하여 구현하였습니다. (썸네일, 파일도 빠른 시일 내에 처리해올리겠습니다.)
- api 요청 형식에 맞게 `request` 객체 자체는 `application/json` 타입으로 지정해서 `formData`에 넣어주고, `formData` 자체는 `multipart/form-data` 처리해서 api 보내주는 식으로 구현하였습니다. (@pipisebastian 도서 관리 페이지 api도 동일한 구성으로 알고 있는데 참고해주세요!)
- 게시판 글쓰기 버튼 클릭 -> 게시글 작성 -> 업로드 -> 게시판으로 이동 flow 가능하도록 처리된 상태입니다.
- 게시판 카테고리는 아직 적용이 안 된 상태여서 자유게시판, 익명게시판 등의 카테고리 다루는 부분은 포함되지 않은 상태입니다. 나중에 게시판 구현할 때 같이 처리해보겠습니다.

## 리뷰 요구사항
- 10분
