### PR TITLE
Feature/게시글 조회 api 연동 #492

### DIFF
--- a/src/api/commentApi.ts
+++ b/src/api/commentApi.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import { useMutation, useQuery } from 'react-query';
+import { CommentInfo } from './dto';
+
+const useCreateCommentMutation = () => {
+  // TODO 업데이트시 조회 목록도 업데이트 되도록 처리
+  // TODO 파라미터 받아오도록 처리
+  const fetcher = () =>
+    axios.post(`/comments`, { postId: 16, content: '댓글2작성 테스트' }).then(({ data }) => data.comments);
+
+  return useMutation(fetcher);
+};
+
+const useGetCommentQuery = (postId: number) => {
+  const fetcher = () => axios.get(`/comments/posts/${postId}`).then(({ data }) => data.comments);
+
+  return useQuery<CommentInfo[]>(['comments'], fetcher);
+};
+
+export { useCreateCommentMutation, useGetCommentQuery };

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -115,14 +115,8 @@ export interface FileInfo {
 }
 
 export interface AdjacentPostInfo {
-  previous: {
-    postId: number;
-    title: string;
-  };
-  next: {
-    postId: number;
-    title: string;
-  };
+  postId: number;
+  title: string;
 }
 
 export interface PostInfo {
@@ -134,7 +128,8 @@ export interface PostInfo {
   thumbnailPath: string;
   content: string;
   files: FileInfo[];
-  adjacentPosts: AdjacentPostInfo;
+  previousPost: AdjacentPostInfo;
+  nextPost: AdjacentPostInfo;
   likeCount: number;
   dislikeCount: number;
   allowComment: boolean;

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { useMutation } from 'react-query';
-import { UploadPost } from './dto';
+import { useMutation, useQuery } from 'react-query';
+import { PostInfo, UploadPost } from './dto';
 
 const useUploadPostMutation = () => {
   const fetcher = (postInfo: UploadPost) => {
@@ -17,4 +17,10 @@ const useUploadPostMutation = () => {
   return useMutation(fetcher);
 };
 
-export default useUploadPostMutation;
+const useGetEachPostQuery = (postId: number) => {
+  const fetcher = () => axios.get(`/posts/${postId}`).then(({ data }) => data);
+
+  return useQuery<PostInfo>(['post'], fetcher);
+};
+
+export { useUploadPostMutation, useGetEachPostQuery };

--- a/src/components/Image/ServerImg.tsx
+++ b/src/components/Image/ServerImg.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import LogoNeon from '@assets/logo/logo_neon.svg';
+
+interface ServerImg {
+  src: string;
+  alt: string;
+  className?: string;
+  errorClassName?: string;
+}
+
+const ServerImg = ({ src, alt, className, errorClassName }: ServerImg) => {
+  const [error, setError] = useState(false);
+  const srcWithServerUrl = `${process.env.REACT_APP_API_URL}/${src}`;
+
+  const handleImgError: React.ReactEventHandler<HTMLImageElement> = (e) => {
+    e.currentTarget.src = LogoNeon;
+    setError(true);
+  };
+
+  return (
+    <img src={srcWithServerUrl} alt={alt} onError={handleImgError} className={error ? errorClassName : className} />
+  );
+};
+
+export default ServerImg;

--- a/src/mocks/postApi.ts
+++ b/src/mocks/postApi.ts
@@ -6,7 +6,7 @@ const post: PostInfo = {
   writerName: 'UmbEizQdxY',
   writerThumbnailPath: null,
   visitCount: 1,
-  thumbnailPath: 'keeper_files/thumbnail/2023-07-10/46683d42-5b7d-4eb7-a52e-249684557551.jpeg',
+  thumbnailPath: 'https://avatars.githubusercontent.com/u/78250089?v=4',
   content: '게시글 내용게시글 내용게시글 내용게시글 내용게시글 내용게시글 내용',
   files: [
     {

--- a/src/mocks/postApi.ts
+++ b/src/mocks/postApi.ts
@@ -26,15 +26,13 @@ const post: PostInfo = {
       uploadTime: '2023-07-10 10:48:23',
     },
   ],
-  adjacentPosts: {
-    previous: {
-      postId: 110,
-      title: '보통 절판된 책 어디서 보나요 ㅠㅠ',
-    },
-    next: {
-      postId: 112,
-      title: '[유용한 만화] 만화로 배우는 https',
-    },
+  previousPost: {
+    postId: 110,
+    title: '보통 절판된 책 어디서 보나요 ㅠㅠ',
+  },
+  nextPost: {
+    postId: 112,
+    title: '[유용한 만화] 만화로 배우는 https',
   },
   likeCount: 0,
   dislikeCount: 0,

--- a/src/pages/BoardWrite/BoardWrite.tsx
+++ b/src/pages/BoardWrite/BoardWrite.tsx
@@ -6,7 +6,7 @@ import StandardInput from '@components/Input/StandardInput';
 import StandardEditor from '@components/Editor/StandardEditor';
 import FileUploader from '@components/Uploader/FileUploader';
 import OutlinedButton from '@components/Button/OutlinedButton';
-import useUploadPostMutation from '@api/postApi';
+import { useUploadPostMutation } from '@api/postApi';
 import { UploadPostSettings } from '@api/dto';
 import { useNavigate } from 'react-router-dom';
 import SettingUploadModal from './Modal/SettingUploadModal';

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -6,7 +6,7 @@ import PostSection from './Section/PostSection';
 import BannerSection from './Section/BannerSection';
 
 const BoardView = () => {
-  const postId = 15; // TODO 게시판 목록에서 받아오기
+  const postId = 16; // TODO 게시판 목록에서 받아오기
   const { data: postInfo } = useGetEachPostQuery(postId);
 
   if (!postInfo) return null;
@@ -18,7 +18,7 @@ const BoardView = () => {
         <PostSection post={postInfo} />
       </div>
       <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
-      <CommentSection />
+      <CommentSection postId={postId} allowComment={postInfo.allowComment} />
     </div>
   );
 };

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -6,7 +6,7 @@ import PostSection from './Section/PostSection';
 import BannerSection from './Section/BannerSection';
 
 const BoardView = () => {
-  const postId = 2; // TODO 게시판 목록에서 받아오기
+  const postId = 15; // TODO 게시판 목록에서 받아오기
   const { data: postInfo } = useGetEachPostQuery(postId);
 
   if (!postInfo) return null;
@@ -14,7 +14,7 @@ const BoardView = () => {
   return (
     <div className="-mt-16 space-y-12">
       <div className="space-y-2">
-        <BannerSection />
+        <BannerSection post={postInfo} />
         <PostSection post={postInfo} />
       </div>
       <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import post from '@mocks/postApi';
+import { useGetEachPostQuery } from '@api/postApi';
 import CommentSection from './Section/CommentSection';
 import AdjacentPostNavSection from './Section/AdjacentPostNavSection';
 import PostSection from './Section/PostSection';
 import BannerSection from './Section/BannerSection';
 
 const BoardView = () => {
-  const postInfo = post; // TODO API 적용
+  const postId = 2; // TODO 게시판 목록에서 받아오기
+  const { data: postInfo } = useGetEachPostQuery(postId);
+
+  if (!postInfo) return null;
 
   return (
     <div className="-mt-16 space-y-12">
@@ -14,7 +17,7 @@ const BoardView = () => {
         <BannerSection />
         <PostSection />
       </div>
-      <AdjacentPostNavSection adjacentPosts={postInfo.adjacentPosts} />
+      <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
       <CommentSection />
     </div>
   );

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -15,7 +15,7 @@ const BoardView = () => {
     <div className="-mt-16 space-y-12">
       <div className="space-y-2">
         <BannerSection />
-        <PostSection />
+        <PostSection post={postInfo} />
       </div>
       <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
       <CommentSection />

--- a/src/pages/board/BoardView/Card/CommentCard.tsx
+++ b/src/pages/board/BoardView/Card/CommentCard.tsx
@@ -7,16 +7,20 @@ import CommentCardFooter from './CommentCardFooter';
 
 interface CommentCardProps {
   commentInfo: CommentInfo;
+  replyComments: CommentInfo[];
 }
 
-const CommentCard = ({ commentInfo }: CommentCardProps) => {
+const CommentCard = ({ commentInfo, replyComments }: CommentCardProps) => {
   return (
     <Card className="!bg-mainBlack !bg-none">
       <CommentCardHeader commentInfo={commentInfo} />
       <CardContent className="mb-5 !px-16">
         <Typography marginBottom={5}>{commentInfo.content}</Typography>
-        {/* TODO 필터링된 대댓글 map으로 관리 */}
-        <ReplyCard commentInfo={commentInfo} />
+        <div className="space-y-3">
+          {replyComments.map((replyComment) => (
+            <ReplyCard key={replyComment.commentId} commentInfo={replyComment} />
+          ))}
+        </div>
       </CardContent>
       <CommentCardFooter commentInfo={commentInfo} />
     </Card>

--- a/src/pages/board/BoardView/Card/CommentCardFooter.tsx
+++ b/src/pages/board/BoardView/Card/CommentCardFooter.tsx
@@ -29,7 +29,8 @@ const CommentCardFooter = ({ commentInfo }: CommentCardFooterProps) => {
         />
       ) : (
         <>
-          <Avatar alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />
+          {/* TODO 현재 계정 프로필 썸네일 가져오기 */}
+          <Avatar className="!h-7 !w-7" alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />
           <button
             type="button"
             className="flex h-9 w-full items-center border border-subBlack bg-mainBlack pl-3"

--- a/src/pages/board/BoardView/Card/CommentCardHeader.tsx
+++ b/src/pages/board/BoardView/Card/CommentCardHeader.tsx
@@ -12,7 +12,7 @@ interface CommentCardHeaderProps {
 const CommentCardHeader = ({ commentInfo }: CommentCardHeaderProps) => {
   return (
     <CardHeader
-      avatar={<Avatar alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />}
+      avatar={<Avatar className="!h-7 !w-7" alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />}
       action={
         <div className="space-x-2">
           <OutlinedButton startIcon={<MdThumbUp />}>{commentInfo.likeCount}</OutlinedButton>

--- a/src/pages/board/BoardView/Section/AdjacentPostNavSection.tsx
+++ b/src/pages/board/BoardView/Section/AdjacentPostNavSection.tsx
@@ -4,32 +4,41 @@ import { Button, Stack, Typography } from '@mui/material';
 import { VscChevronLeft, VscChevronRight } from 'react-icons/vsc';
 
 interface AdjacentPostNavSectionProps {
-  adjacentPosts: AdjacentPostInfo;
+  previousPost: AdjacentPostInfo | null;
+  nextPost: AdjacentPostInfo | null;
 }
 
-const AdjacentPostNavSection = ({ adjacentPosts }: AdjacentPostNavSectionProps) => {
+const AdjacentPostNavSection = ({ previousPost, nextPost }: AdjacentPostNavSectionProps) => {
   return (
     <section className="flex justify-between">
-      <Button className="h-24 w-96 !justify-start !px-10" startIcon={<VscChevronLeft />}>
-        <Stack textAlign="left">
-          <Typography variant="small" fontWeight="semibold">
-            이전글
-          </Typography>
-          <Typography color="white" fontWeight="semibold">
-            {adjacentPosts.previous.title}
-          </Typography>
-        </Stack>
-      </Button>
-      <Button className="h-24 w-96 !justify-end !px-10" endIcon={<VscChevronRight />}>
-        <Stack textAlign="right">
-          <Typography variant="small" fontWeight="semibold">
-            다음글
-          </Typography>
-          <Typography color="white" fontWeight="semibold">
-            {adjacentPosts.next.title}
-          </Typography>
-        </Stack>
-      </Button>
+      <div>
+        {previousPost && (
+          <Button className="h-24 w-96 !justify-start !px-10" startIcon={<VscChevronLeft />}>
+            <Stack textAlign="left">
+              <Typography variant="small" fontWeight="semibold">
+                이전글
+              </Typography>
+              <Typography color="white" fontWeight="semibold">
+                {previousPost.title}
+              </Typography>
+            </Stack>
+          </Button>
+        )}
+      </div>
+      <div>
+        {nextPost && (
+          <Button className="h-24 w-96 !justify-end !px-10" endIcon={<VscChevronRight />}>
+            <Stack textAlign="right">
+              <Typography variant="small" fontWeight="semibold">
+                다음글
+              </Typography>
+              <Typography color="white" fontWeight="semibold">
+                {nextPost.title}
+              </Typography>
+            </Stack>
+          </Button>
+        )}
+      </div>
     </section>
   );
 };

--- a/src/pages/board/BoardView/Section/BannerSection.tsx
+++ b/src/pages/board/BoardView/Section/BannerSection.tsx
@@ -1,21 +1,44 @@
 import React from 'react';
-import { Chip, Typography } from '@mui/material';
+import { Avatar, Chip, Typography } from '@mui/material';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import { PostInfo } from '@api/dto';
+import { VscCalendar, VscEye } from 'react-icons/vsc';
+import ServerImg from '@components/Image/ServerImg';
 
-const BannerSection = () => {
+interface BannerSectionProps {
+  post: PostInfo;
+}
+
+const BannerSection = ({ post }: BannerSectionProps) => {
   return (
     <div className="relative bg-mainBlack px-6 py-2">
-      <img
-        src="https://avatars.githubusercontent.com/u/78250089?v=4"
-        alt="post thumbnail"
-        className="absolute inset-0 h-full w-full object-cover opacity-10"
-      />
+      <div className="opacity-10">
+        <ServerImg
+          src={post.thumbnailPath}
+          alt="post thumbnail"
+          className="absolute inset-0 h-full w-full object-cover"
+          errorClassName="absolute inset-0 h-2/3 w-2/3 m-auto"
+        />
+      </div>
       <div className="mx-auto mt-10 max-w-xl text-center">
-        <Chip className="mb-4 !rounded-md !bg-pointBlue/50" label="자유게시판" />
+        <Chip className="mb-4 !rounded-md !bg-pointBlue/50" label={post.categoryName} />
         <Typography variant="h3" className="flex h-12 items-center justify-center !font-semibold">
-          게시글 제목입니다.
+          {post.title}
         </Typography>
-        <p className="text-small leading-8 text-gray-300">작성자-작성시간-조회수</p>
+        <div className="flex items-center justify-center gap-2 text-small leading-8 text-gray-300">
+          <div className="flex items-center justify-center">
+            <Avatar className="mr-1 !h-4 !w-4" src={post.writerThumbnailPath ?? undefined} />
+            {post.writerName}
+          </div>
+          <div className="flex items-center justify-center">
+            <VscCalendar className="mr-1 h-4 w-4" />
+            {post.registerTime}
+          </div>
+          <div className="flex items-center justify-center">
+            <VscEye className="mr-1 h-4 w-4" />
+            {post.visitCount}
+          </div>
+        </div>
       </div>
       <div className="flex justify-end space-x-2">
         <OutlinedButton>글 수정</OutlinedButton>

--- a/src/pages/board/BoardView/Section/CommentSection.tsx
+++ b/src/pages/board/BoardView/Section/CommentSection.tsx
@@ -1,17 +1,36 @@
 import React from 'react';
 import { Card, CardActions, Typography } from '@mui/material';
 import CustomBadge from '@components/Badge/CustomBadge';
-import comments from '@mocks/commentApi';
+import { useCreateCommentMutation, useGetCommentQuery } from '@api/commentApi';
+import { CommentInfo } from '@api/dto';
 import CommentCard from '../Card/CommentCard';
 import CommentWriteCardAction from '../Card/CommentWriteCardAction';
 
-const CommentSection = () => {
-  const commentList = comments; // TODO API 받아오기 (댓글, 대댓글 필터링 필요)
-  const commentCount = comments.length;
+interface CommentSectionProps {
+  allowComment: boolean;
+  postId: number;
+}
+
+const CommentSection = ({ allowComment, postId }: CommentSectionProps) => {
+  const { data: commentList } = useGetCommentQuery(postId); // TODO postId 정상적으로 받아오지 않을 경우 처리
+  const { mutate } = useCreateCommentMutation();
 
   const handleWriteCommentClick = () => {
     // TODO 댓글 작성 API 적용
+    mutate();
   };
+
+  const getParentComment = (comments: CommentInfo[]) => {
+    return comments.filter((comment) => comment.parentId === null);
+  };
+
+  const getReplyComment = (comments: CommentInfo[], parentId: number | null) => {
+    return comments.filter((comment) => comment.parentId === parentId);
+  };
+
+  if (!commentList || !allowComment) {
+    return null;
+  }
 
   return (
     <section>
@@ -19,12 +38,18 @@ const CommentSection = () => {
         <Typography variant="h3" marginRight={1} className="!font-semibold">
           댓글
         </Typography>
-        <CustomBadge>{commentCount}</CustomBadge>
+        <CustomBadge>{commentList.length}</CustomBadge>
       </div>
-      {commentList.map((comment) => (
-        <CommentCard key={comment.commentId} commentInfo={comment} />
-      ))}
-      <Card className="mt-11">
+      <div className="space-y-4">
+        {getParentComment(commentList).map((comment) => (
+          <CommentCard
+            key={comment.commentId}
+            commentInfo={comment}
+            replyComments={getReplyComment(commentList, comment.commentId)}
+          />
+        ))}
+      </div>
+      <Card className={commentList.length > 0 ? 'mt-11' : ''}>
         <CardActions className="border-t border-subBlack bg-middleBlack">
           <CommentWriteCardAction
             textFieldProps={{ placeholder: '댓글...' }}

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import StandardViewer from '@components/Viewer/StandardViewer';
-import post from '@mocks/postApi';
 import FilledButton from '@components/Button/FilledButton';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import { VscArrowDown, VscArrowUp, VscFile } from 'react-icons/vsc';
+import { PostInfo } from '@api/dto';
 
-const PostSection = () => {
+interface PostSectionProps {
+  post: PostInfo;
+}
+
+const PostSection = ({ post }: PostSectionProps) => {
   return (
     <div className="min-h-[520px] bg-middleBlack px-14 py-10">
       <StandardViewer className="min-h-[330px]" content={post.content} />
@@ -20,11 +24,11 @@ const PostSection = () => {
       <div className="flex items-center justify-center space-x-2">
         <FilledButton small>
           <VscArrowUp className="mr-1" size={10} />
-          <span>추천 (5)</span>
+          <span>추천 ({post.likeCount})</span>
         </FilledButton>
         <OutlinedButton small>
           <VscArrowDown className="mr-1" size={10} />
-          <span>비추천 (5)</span>
+          <span>비추천 ({post.dislikeCount})</span>
         </OutlinedButton>
       </div>
     </div>


### PR DESCRIPTION
## 연관 이슈
- Close #492 

## 작업 요약
- 배너, 게시글 내용, 댓글 섹션에 필요한 api 연동 해주었습니다.
- 댓글 섹션은 조회 api만 적용해둔 상태이고 댓글/대댓글 생성, 수정, 삭제 및 좋아요/싫어요 처리 관련해서는 별도의 이슈(#494)에서 진행 예정입니다.

## 작업 상세 설명
- 각 api 연동 및 연동 후 수정 필요한 부분 수정해주었습니다.
- 서버에서 받아오는 이미지 처리를 위해 공통컴포넌트로 만들어주었습니다!
  서버에서 정상적으로 이미지 받아오는 경우와 정상적으로 이미지 받아오지 않는 경우에 대해서 처리하도록 구현하였습니다.
  - 서버 이미지는 상대경로로 제공되기 때문에 props로 `src` 넘겨주면 `src` 앞에 서버 주소를 붙여주도록 해주었습니다.
  - 이미지를 정상적으로 받아오지 못할 경우 썸네일 기본 이미지인 로고 이미지를 띄워주도록 해주었습니다.
  - 정상적으로 이미지 받아올 경우, 받아오지 못할 경우 스타일을 다르게 적용할 수 있기 때문에 각각 `className`과 `errorClassName`을 props로 받아올 수 있도록 해주었습니다!

## 리뷰 요구사항
- ~~#491 선행 PR 먼저 리뷰 부탁드립니다!~~ 머지 완료
- 이 PR은 [feat: 이전글, 다음글 받아온 api 적용](https://github.com/KEEPER31337/Homepage-Front-R2/commit/3a54bbb91ffc37710e3b9f17b44684c4b3efd7ae) 부터 보시면 됩니다!

## Preview 이미지
<img width="390" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/dd940af2-dc9b-4df4-b675-cc083cf71b43">
