### PR TITLE
Feature/StandardTablePagination 외부 props 받아와 제어 #499

### DIFF
--- a/src/components/Pagination/StandardTablePagination.interface.ts
+++ b/src/components/Pagination/StandardTablePagination.interface.ts
@@ -1,0 +1,4 @@
+export interface PaginationOption {
+  rowsPerPage?: number;
+  totalItems?: number;
+}

--- a/src/components/Pagination/StandardTablePagination.tsx
+++ b/src/components/Pagination/StandardTablePagination.tsx
@@ -1,17 +1,15 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Pagination, TablePagination } from '@mui/material';
 
 import './pagination.css';
+import { PaginationOption } from './StandardTablePagination.interface';
 
-interface StandardTablePaginationProps {
-  rowsPerPage?: number;
-}
-
-const StandardTablePagination = ({ rowsPerPage = 10 }: StandardTablePaginationProps) => {
-  const totalItems = 100; // TODO - 임시 값
+const StandardTablePagination = ({ rowsPerPage = 10, totalItems = -1 }: PaginationOption) => {
   const totalPages = Math.ceil(totalItems / rowsPerPage);
 
   const [page, setPage] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const setoffPageDiff = (prevPage: number, reverse?: boolean) => {
     // TablePagination page의 인덱스와 Pagination page의 인덱스 간 차이(1) 상쇄를 위한 동작입니다.
@@ -20,7 +18,17 @@ const StandardTablePagination = ({ rowsPerPage = 10 }: StandardTablePaginationPr
 
   const handleChangePage = (event: React.ChangeEvent<unknown>, newPage: number) => {
     setPage(setoffPageDiff(newPage, true));
+    setSearchParams({ page: String(newPage) });
   };
+
+  useEffect(() => {
+    if (!searchParams.get('page')) {
+      setSearchParams({ page: String(setoffPageDiff(page)) });
+      return;
+    }
+
+    setPage(setoffPageDiff(Number(searchParams.get('page')), true));
+  }, []);
 
   return (
     <div className="flex !w-full items-center justify-between bg-middleBlack">
@@ -34,7 +42,7 @@ const StandardTablePagination = ({ rowsPerPage = 10 }: StandardTablePaginationPr
         }}
         rowsPerPage={rowsPerPage}
         rowsPerPageOptions={[]}
-        labelDisplayedRows={({ from, to, count }) => `Showing ${from}-${to} of ${count} items`}
+        labelDisplayedRows={({ from, to, count }) => `Showing ${from}-${to} of ${Math.max(count, 0)} items`}
       />
       <Pagination
         color="secondary"

--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { Checkbox, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
 
 import StandardTablePagination from '@components/Pagination/StandardTablePagination';
+import { PaginationOption } from '@components/Pagination/StandardTablePagination.interface';
 import { ChildComponent, Column, Row } from './StandardTable.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,6 +11,7 @@ interface StandardTableProps<T extends Record<string, any>> {
   rows: Row<T>[];
   onRowClick?: ({ rowData }: { rowData: Row<T> }) => void;
   childComponent?: ({ key, value, rowData }: ChildComponent<T>) => ReactNode;
+  paginationOption?: PaginationOption;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,6 +20,7 @@ const StandardTable = <T extends Record<string, any>>({
   rows,
   onRowClick,
   childComponent,
+  paginationOption,
 }: StandardTableProps<T>) => {
   const isCheckboxColumn = (columnKey: Column<T>['key']) => columnKey === 'checkbox';
 
@@ -71,7 +74,7 @@ const StandardTable = <T extends Record<string, any>>({
           ))}
         </TableBody>
       </Table>
-      <StandardTablePagination rowsPerPage={10} />
+      <StandardTablePagination {...paginationOption} />
     </div>
   );
 };

--- a/src/hooks/useGetPage.ts
+++ b/src/hooks/useGetPage.ts
@@ -1,0 +1,11 @@
+import { useSearchParams } from 'react-router-dom';
+
+const useGetPage = () => {
+  const [searchParams] = useSearchParams();
+
+  if (!searchParams.get('page')) return { page: 0 };
+
+  return { page: Number(searchParams.get('page')) - 1 };
+};
+
+export default useGetPage;


### PR DESCRIPTION
## 연관 이슈
- Close #499 
- #130 

## 작업 요약
- 페이지네이션으로 테이블 목록 제어할 수 있도록 확장해주었습니다.

## 작업 상세 설명
- 페이지네이션에서 page를 url searchParam으로 부여하도록 처리하였습니다.
- 페이지에 따른 목록을 불러올 때 searchParam으로 page를 불러와 사용하면 되는데 UI 상에서 띄워주는 page는 1부터 시작이고, api에서 받는 page는 0부터 시작이기 때문에 searchParam을 불러오는 부분과 page api 형식에 맞게 변환하는 부분을 합쳐 `useGetPage`라는 커스텀 훅을 제작하였습니다.
- 사용되는 부분 예시입니다. 예시로 간략하게 보여주기 위한 거라 코드가 좀 이상할 수 있는데 `useGetPage`로 page 불러와 api 파라미터로 넘겨줄 수 있다는 것과, `paginationOption`으로 페이지네이션 관련 정보 넣어줄 수 있다는 것만 확인해주세요!
  ```tsx
  const BoardList = () => {
    const { page } = useGetPage();
    const { data: posts } = useGetPostListQuery({ categoryId: 104, page });
  
    if (!posts) {
      return null;
    }
  
    return (
      <StandardTable
        columns={boardColumn}
        rows={posts.content.map((post) => ({ no: post.id, ...post }))}
        paginationOption={{ rowsPerPage: posts.size, totalItems: posts.totalElements }}
      />
    );
  };
  ```

## 리뷰 요구사항
- 예상 소요 시간 7분
- 전체적으로 문제될만한 부분이 없는 지, 처리 방식이 괜찮은 지 살펴봐주시면 감사하겠습니다!