### PR TITLE
Feature/실행 스크립트에 cross-env 추가 #522

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^17.0.62",
         "@types/react-dom": "^17.0.1",
         "axios": "^1.3.2",
+        "cross-env": "^7.0.3",
         "luxon": "^3.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -6300,6 +6301,23 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -21571,6 +21589,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^17.0.62",
     "@types/react-dom": "^17.0.1",
     "axios": "^1.3.2",
+    "cross-env": "^7.0.3",
     "luxon": "^3.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -32,7 +33,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "GENERATE_SOURCEMAP=false craco start",
+    "start": "cross-env GENERATE_SOURCEMAP=false craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "craco eject"


### PR DESCRIPTION
## 연관 이슈
#462 #522 

## 작업 요약
corss-env 모듈 설치로 모든 os에서의 실행 스크립트를 통일해주었습니다.

## 작업 상세 설명
> cross-env 모듈은 프로젝트 참여자 각각이 MacOS, Windows, Linux 등 다양한 OS 마다 환경변수를 설정하는 방법이 다르기 때문에 이것에 대한 대책을 마련한 모듈이다. 그래서 corss-env 패키지를 사용하면 동적으로 process.env(환경 변수)를 변경할 수 있으며 모든 운영체제에서 동일한 방법으로 환경 변수를 변경할 수 있게 된다.
[참고](https://inpa.tistory.com/entry/NODE-%F0%9F%93%9A-cross-env-%EB%AA%A8%EB%93%88-%EC%82%AC%EC%9A%A9%EB%B2%95)

실행 스크립트 내 `GENERATE_SOURCEMAP=false craco start `추가로(https://github.com/KEEPER31337/Homepage-Front-R2/issues/462) 윈도우 os에서는 start 스크립트가 실행되지 않는 오류가 있었습니다. 
기존에는 window용 실행 스크립트(winStart 같이..)를 따로 만들어 추가할 생각이었지만 그러면 윈도우에서 코드를 실행시킬때` npm run winStart`처럼 작성해야하는 번거로움이 있었고, winStart처럼 스크립트를 분리시키는 것보다 cross-env로 통일시키는 게 나을 거 같아 cross-env를 적용시켰습니다

이거 하나 하자고 모듈을 하나 다운받아야 해서 그게 좀 그렇긴 한데...^^;

## 리뷰 요구사항
1. 그냥 `GENERATE_SOURCEMAP=false craco start ` 삭제
2. winStart 스크립트 분리
3. cross-env 사용(해당 PR에 적용된 내용)
이 세 개 중에 어느 게 나을지 의견 부탁드립니다!

## Preview 이미지
