### PR TITLE
Feature/에러_공통_처리_훅_제작_#524

### DIFF
--- a/src/hooks/useGetApiError.ts
+++ b/src/hooks/useGetApiError.ts
@@ -1,0 +1,94 @@
+/* eslint-disable no-console */
+import { AxiosError } from 'axios';
+import { useCallback } from 'react';
+
+type ErrorHandler = (error?: AxiosError) => void;
+
+interface ServiceCodeHandler {
+  [key: number]: ErrorHandler;
+  default?: ErrorHandler;
+}
+
+interface HttpStatusHandlers {
+  [key: number]: ServiceCodeHandler;
+  default?: ErrorHandler;
+}
+
+interface DefaultHandler {
+  default: ErrorHandler;
+}
+
+interface DefaultHttpStatusHandlers extends DefaultHandler {
+  [key: number]: ServiceCodeHandler & DefaultHandler;
+}
+
+/* NOTE 현재 백엔드에서 반환하는 HTTP 에러
+  400 - BAD_REQUEST
+  401 - UNAUTHORIZED
+  403 - FORBIDDEN
+  404 - NOT_FOUND
+  409 - CONFICT
+  500 - SERVER_ERROR
+*/
+
+const defaultHandlers: DefaultHttpStatusHandlers = {
+  default: () => {
+    console.log('알 수 없는 에러가 발생하였습니다.');
+  },
+  400: {
+    default: () => {
+      console.log('400 에러 발생');
+    },
+  },
+  401: {
+    default: () => {
+      console.log('401 에러 발생');
+    },
+  },
+  403: {
+    default: () => {
+      console.log('403 에러 발생');
+    },
+  },
+  409: {
+    default: () => {
+      console.log('409 에러 발생');
+    },
+  },
+  500: {
+    default: () => {
+      console.log('500 에러 발생');
+    },
+  },
+};
+
+const useApiError = (handlers?: HttpStatusHandlers) => {
+  const handleError = useCallback(
+    (error, serviceCode) => {
+      const httpStatus: number = error.response.status;
+
+      if (handlers && handlers[httpStatus][serviceCode]) {
+        // 우선순위 1. 컴포넌트에서 (HTTP Status, 서비스 표준 에러 Code) Key 조합으로 재정의한 핸들러
+        handlers[httpStatus][serviceCode]();
+      } else if (handlers && handlers[httpStatus]) {
+        // 우선순위 2. 컴포넌트에서 (HTTP Status) Key로 재정의한 핸들러
+        handlers[httpStatus].default?.();
+      } else if (defaultHandlers[httpStatus][serviceCode]) {
+        // 우선순위 3. Hook에서 (HTTP Status, 서비스 표준 에러 Code) Key 조합으로 정의한 핸들러
+        defaultHandlers[httpStatus][serviceCode]();
+      } else if (defaultHandlers[httpStatus]) {
+        // 우선순위 4. Hook에서 (HTTP Status) Key로 정의한 핸들러
+        defaultHandlers[httpStatus].default();
+      } else {
+        // 우선순위 5. 어디에서도 정의되지 못한 에러를 처리하는 핸들러
+        defaultHandlers.default();
+      }
+    },
+    [handlers],
+  );
+
+  return { handleError };
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { useApiError };

--- a/src/hooks/useGetApiError.ts
+++ b/src/hooks/useGetApiError.ts
@@ -64,7 +64,7 @@ const defaultHandlers: DefaultHttpStatusHandlers = {
 
 const useApiError = (handlers?: HttpStatusHandlers) => {
   const handleError = useCallback(
-    (error, serviceCode) => {
+    (error, serviceCode?) => {
       const httpStatus: number = error.response.status;
 
       if (handlers && handlers[httpStatus][serviceCode]) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,37 +5,49 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { ThemeProvider as MUIThemeProvider } from '@mui/material';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from 'react-query';
 import axios from 'axios';
 
 import './tailwind.css';
 import muiTheme from '@constants/muiTheme';
+import { useApiError } from '@hooks/useGetApiError';
 import App from './App';
 
 axios.defaults.baseURL = process.env.REACT_APP_API_URL;
 axios.defaults.withCredentials = true;
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-    },
-  },
-});
+const Index = () => {
+  const { handleError } = useApiError();
 
-ReactDOM.render(
-  <React.StrictMode>
-    <RecoilRoot>
-      <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <MUIThemeProvider theme={muiTheme}>
-          <BrowserRouter>
-            <QueryClientProvider client={queryClient}>
-              <App />
-            </QueryClientProvider>
-          </BrowserRouter>
-        </MUIThemeProvider>
-      </LocalizationProvider>
-    </RecoilRoot>
-  </React.StrictMode>,
-  document.getElementById('root') as HTMLElement,
-);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+    queryCache: new QueryCache({
+      onError: handleError,
+    }),
+    mutationCache: new MutationCache({
+      onError: handleError,
+    }),
+  });
+
+  return (
+    <React.StrictMode>
+      <RecoilRoot>
+        <LocalizationProvider dateAdapter={AdapterLuxon}>
+          <MUIThemeProvider theme={muiTheme}>
+            <BrowserRouter>
+              <QueryClientProvider client={queryClient}>
+                <App />
+              </QueryClientProvider>
+            </BrowserRouter>
+          </MUIThemeProvider>
+        </LocalizationProvider>
+      </RecoilRoot>
+    </React.StrictMode>
+  );
+};
+
+ReactDOM.render(<Index />, document.getElementById('root') as HTMLElement);


### PR DESCRIPTION
## 연관 이슈
- Close #524

## 작업 요약
- 에러 공통적으로 처리 하도록 하였습니다.

## 작업 상세 설명
- index.tsx에서 `QueryClient` 선언할 때 모든 API 에러 발생 상황에서 핸들러 작동하도록 해두었습니다! -> 별도의 에러 처리 없이 기본적인 에러 핸들러 사용하려면 개개인이 별도로 코드 추가할 필요없이 자동으로 default 에러 핸들러 적용 됩니다.
- 만약 에러 커스텀이 필요하면 호출하는 부분에서 변경할 수 있습니다.
  만약 http 에러 자체를 커스텀하고 싶으면 default 값으로 써주면 되고,
  ```tsx
  import { useApiError } from '@hooks/useGetApiError';
  
  const useUploadPostMutation = () => {
    const { handleError } = useApiError({
      400: {
        default: () => {
          console.log('필수값이 입력되지 않았습니다.');
        },
      },
    });
  
    const fetcher = (postInfo: UploadPost) => {...};
  
    return useMutation(fetcher, { onError: handleError });
  };
  ```
  만약 같은 http 에러를 세부적으로 나눠 커스텀하고 싶으면
  ```tsx
  import { useApiError } from '@hooks/useGetApiError';

  const useUploadPostMutation = () => {
    const { handleError } = useApiError({
      400: {
        40001: () => {
          console.log('제목이 입력되지 않았습니다.');
        },
        40002: () => {
          console.log('내용이 입력되지 않았습니다.');
        },
      },
    });
  
    const fetcher = (postInfo: UploadPost) => {...};
  
    return useMutation(fetcher, {
      onError: (err) => {
        if (!title) return handleError(err, 40001);
        if (!content) return handleError(err, 40002);
        return handleError(err);
      },
    });
  ```

## 리뷰 요구사항
- 커스텀 훅 사용을 위해 `Index`라는 컴포넌트를 만들어서 `ReactDOM.render`에 넣어주는 방식으로 처리하였는데 이런 방식 문제 없을 지 체크 부탁드립니다.
- `defaultHandlers`에 지금은 일단 console로 찍어놓았는데 각각 에러 상태에 맞게 추후 추가 작업 예정입니다. `ex. 401 에러 발생 시 로그인 페이지로 이동`
- 코드에 로직 이해가 조금 까다로울 수 있을 것 같아 주석 추가해두었는데 불필요하다 생각되면 말해주세요!
- `defaultHandlers`의 경우에는 default 함수가 이 필수적으로 들어가야 하는데 커스텀해서 받아오는 `handlers`에는 default가 없어도 되기 때문에 타입 처리 나눠서 한다고 조금 지저분해졌습니다... 혹시 더 깔끔하게 타입 처리할 수 있는 방법 아신다면 알려주세요!