### PR TITLE
Feature/로그인 시 계정 정보 저장 및 헤더 반영 #530

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import memberState from '@recoil/member.recoil';
+
+const useSignOutMutation = () => {
+  const fetcher = () => axios.post(`/sign-out`);
+
+  const navigate = useNavigate();
+  const setMemberState = useSetRecoilState(memberState);
+
+  return useMutation(fetcher, {
+    onSuccess: () => {
+      navigate('/');
+      setMemberState(null);
+    },
+  });
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { useSignOutMutation };

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -13,7 +13,8 @@ export type Role =
   | 'ROLE_출제자';
 
 export interface MemberInfo {
-  id: number;
+  memberId: number;
+  loginId: number;
   emailAddress: string;
   realName: string;
   thumbnailPath: string | null;

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -1,3 +1,36 @@
+export type Role =
+  | 'ROLE_회장'
+  | 'ROLE_부회장'
+  | 'ROLE_서기'
+  | 'ROLE_총무'
+  | 'ROLE_사서'
+  | 'ROLE_학술부장'
+  | 'ROLE_대외부장'
+  | 'ROLE_FRONT_전산관리자'
+  | 'ROLE_BACK_전산관리자'
+  | 'ROLE_INFRA_전산관리자'
+  | 'ROLE_회원'
+  | 'ROLE_출제자';
+
+export interface MemberInfo {
+  id: number;
+  emailAddress: string;
+  realName: string;
+  thumbnailPath: string | null;
+  memberJobs: Role[];
+}
+
+export interface MemberDetailInfo extends MemberInfo {
+  birthday: string;
+  studentId: string;
+  generation: number;
+  point: number;
+  level: number;
+  totalAttendance: number;
+  memberType: string;
+  memberRank: string;
+}
+
 export interface StaticWriteContentsInfo {
   id: number;
   content: string;
@@ -203,17 +236,3 @@ export interface BoardPosts {
   numberOfElements: number;
   empty: boolean;
 }
-
-export type Role =
-  | 'ROLE_회장'
-  | 'ROLE_부회장'
-  | 'ROLE_서기'
-  | 'ROLE_총무'
-  | 'ROLE_사서'
-  | 'ROLE_학술부장'
-  | 'ROLE_대외부장'
-  | 'ROLE_FRONT_전산관리자'
-  | 'ROLE_BACK_전산관리자'
-  | 'ROLE_INFRA_전산관리자'
-  | 'ROLE_회원'
-  | 'ROLE_출제자';

--- a/src/api/logInApi.ts
+++ b/src/api/logInApi.ts
@@ -1,19 +1,24 @@
 import axios from 'axios';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import memberState from '@recoil/member.recoil';
+import { MemberDetailInfo } from './dto';
 
 const useLoginMutation = () => {
   const fetcher = ({ loginId, password }: { loginId: string; password: string }) =>
-    axios.post(`/sign-in`, { loginId, password });
+    axios.post(`/sign-in`, { loginId, password }).then(({ data }) => data);
 
   const navigate = useNavigate();
+  const setMemberState = useSetRecoilState(memberState);
 
   return useMutation(fetcher, {
     onError: () => {
       alert('아이디 또는 비밀번호를 확인해주세요.');
     },
-    onSuccess: () => {
+    onSuccess: ({ id, emailAddress, realName, thumbnailPath, memberJobs }: MemberDetailInfo) => {
       navigate('/');
+      setMemberState({ id, emailAddress, realName, thumbnailPath, memberJobs });
     },
   });
 };

--- a/src/api/logInApi.ts
+++ b/src/api/logInApi.ts
@@ -16,9 +16,9 @@ const useLoginMutation = () => {
     onError: () => {
       alert('아이디 또는 비밀번호를 확인해주세요.');
     },
-    onSuccess: ({ id, emailAddress, realName, thumbnailPath, memberJobs }: MemberDetailInfo) => {
+    onSuccess: ({ memberId, loginId, emailAddress, realName, thumbnailPath, memberJobs }: MemberDetailInfo) => {
       navigate('/');
-      setMemberState({ id, emailAddress, realName, thumbnailPath, memberJobs });
+      setMemberState({ memberId, loginId, emailAddress, realName, thumbnailPath, memberJobs });
     },
   });
 };

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import memberState from '@recoil/member.recoil';
 import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { VscAccount, VscGithubInverted } from 'react-icons/vsc';
@@ -8,7 +10,7 @@ import AccountMenu from './Menu/AccountMenu';
 
 const Header = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const userInfo = null; // TODO 로그인 정보 받아와서 set 해줘야할 듯
+  const userInfo = useRecoilValue(memberState);
   const open = Boolean(anchorEl);
 
   const handleAccountIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -29,24 +31,26 @@ const Header = () => {
           <Logo className="h-8" />
         </Link>
         {userInfo ? (
-          <div>
-            <IconButton target="_blank" href="https://keeper.or.kr/wiki/%EB%8C%80%EB%AC%B8">
-              <Typography className="h-6 w-6 rounded-full bg-pointBlue text-mainBlack">W</Typography>
-            </IconButton>
-            <IconButton target="_blank" href="https://github.com/KEEPER31337">
-              <VscGithubInverted fill="#4CEEF9" />
-            </IconButton>
-            <IconButton onClick={handleAccountIconClick}>
-              <VscAccount fill="#4CEEF9" />
-            </IconButton>
-          </div>
+          <>
+            <div>
+              <IconButton target="_blank" href="https://keeper.or.kr/wiki/%EB%8C%80%EB%AC%B8">
+                <Typography className="h-6 w-6 rounded-full bg-pointBlue text-mainBlack">W</Typography>
+              </IconButton>
+              <IconButton target="_blank" href="https://github.com/KEEPER31337">
+                <VscGithubInverted fill="#4CEEF9" />
+              </IconButton>
+              <IconButton onClick={handleAccountIconClick}>
+                <VscAccount fill="#4CEEF9" />
+              </IconButton>
+            </div>
+            <AccountMenu userInfo={userInfo} anchorEl={anchorEl} open={open} onClose={handleMenuClose} />
+          </>
         ) : (
           <Link to="/login">
             <FilledButton>LOGIN</FilledButton>
           </Link>
         )}
       </Toolbar>
-      <AccountMenu anchorEl={anchorEl} open={open} onClose={handleMenuClose} />
     </AppBar>
   );
 };

--- a/src/components/Layout/Header/Menu/AccountMenu.tsx
+++ b/src/components/Layout/Header/Menu/AccountMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Divider, Menu, MenuItem, MenuList } from '@mui/material';
 import { MemberInfo } from '@api/dto';
+import { useSignOutMutation } from '@api/authApi';
 
 interface AccountMenuProps {
   userInfo: MemberInfo;
@@ -10,20 +11,20 @@ interface AccountMenuProps {
 }
 
 const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) => {
-  const accountMenuList = [
-    { id: 1, content: '프로필' },
-    { id: 2, content: '로그아웃' },
-  ];
+  const { mutate: logout } = useSignOutMutation();
+
+  const handleLogOutClick = () => {
+    logout();
+  };
 
   return (
     <Menu anchorEl={anchorEl} open={open} onClose={onClose}>
       <MenuList className="text-center">{userInfo.emailAddress}</MenuList>
       <Divider className="!my-1" />
-      {accountMenuList.map((accountMenu) => (
-        <MenuItem className="min-w-[150px]" key={accountMenu.id}>
-          {accountMenu.content}
-        </MenuItem>
-      ))}
+      <MenuItem className="min-w-[150px]">프로필</MenuItem>
+      <MenuItem className="min-w-[150px]" onClick={handleLogOutClick}>
+        로그아웃
+      </MenuItem>
     </Menu>
   );
 };

--- a/src/components/Layout/Header/Menu/AccountMenu.tsx
+++ b/src/components/Layout/Header/Menu/AccountMenu.tsx
@@ -19,7 +19,7 @@ const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) =>
 
   return (
     <Menu anchorEl={anchorEl} open={open} onClose={onClose}>
-      <MenuList className="text-center">{userInfo.emailAddress}</MenuList>
+      <MenuList className="text-center">{userInfo.loginId}</MenuList>
       <Divider className="!my-1" />
       <MenuItem className="min-w-[150px]">프로필</MenuItem>
       <MenuItem className="min-w-[150px]" onClick={handleLogOutClick}>

--- a/src/components/Layout/Header/Menu/AccountMenu.tsx
+++ b/src/components/Layout/Header/Menu/AccountMenu.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { Menu, MenuItem } from '@mui/material';
+import { Divider, Menu, MenuItem, MenuList } from '@mui/material';
+import { MemberInfo } from '@api/dto';
 
 interface AccountMenuProps {
+  userInfo: MemberInfo;
   anchorEl: HTMLElement | null;
   open: boolean;
   onClose: () => void;
 }
 
-const AccountMenu = ({ anchorEl, open, onClose }: AccountMenuProps) => {
+const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) => {
   const accountMenuList = [
     { id: 1, content: '프로필' },
     { id: 2, content: '로그아웃' },
@@ -15,6 +17,8 @@ const AccountMenu = ({ anchorEl, open, onClose }: AccountMenuProps) => {
 
   return (
     <Menu anchorEl={anchorEl} open={open} onClose={onClose}>
+      <MenuList className="text-center">{userInfo.emailAddress}</MenuList>
+      <Divider className="!my-1" />
       {accountMenuList.map((accountMenu) => (
         <MenuItem className="min-w-[150px]" key={accountMenu.id}>
           {accountMenu.content}

--- a/src/hooks/useCheckAuth.ts
+++ b/src/hooks/useCheckAuth.ts
@@ -7,7 +7,7 @@ const useCheckAuth = () => {
   const member = useRecoilValue(memberState);
 
   const checkAuth = useMemo(() => {
-    return (requiredRole: Role) => member.roles.includes(requiredRole);
+    return (requiredRole: Role) => member?.memberJobs?.includes(requiredRole);
   }, [member]);
 
   const checkIncludeOneOfAuths = useMemo(() => {

--- a/src/hooks/useCheckAuth.ts
+++ b/src/hooks/useCheckAuth.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import { Role } from '@api/dto';
+import { MemberInfo, Role } from '@api/dto';
 import memberState from '@recoil/member.recoil';
 
 const useCheckAuth = () => {
-  const member = useRecoilValue(memberState);
+  const member: MemberInfo | null = useRecoilValue(memberState);
 
   const checkAuth = useMemo(() => {
     return (requiredRole: Role) => member?.memberJobs?.includes(requiredRole);

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -4,8 +4,6 @@ import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import BackgroundInput from '@components/Input/BackgroundInput';
 import { Link } from 'react-router-dom';
 import useLoginMutation from '@api/logInApi';
-import { useSetRecoilState } from 'recoil';
-import memberState from '@recoil/member.recoil';
 
 const HorizonLine = () => {
   return (
@@ -28,7 +26,6 @@ const Login = () => {
   });
   const { id, password } = form;
   const { mutate: login } = useLoginMutation();
-  const setMemberState = useSetRecoilState(memberState);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.currentTarget;
@@ -50,14 +47,7 @@ const Login = () => {
 
   const handleLoginClick = () => {
     if (validation()) {
-      login(
-        { loginId: form.id, password: form.password },
-        {
-          onSuccess: ({ data }) => {
-            setMemberState({ roles: data.memberJobs });
-          },
-        },
-      );
+      login({ loginId: form.id, password: form.password });
     }
   };
 

--- a/src/recoil/member.recoil.ts
+++ b/src/recoil/member.recoil.ts
@@ -1,14 +1,12 @@
-import { Role } from '@api/dto';
+import { MemberInfo } from '@api/dto';
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
-const memberState = atom<{ roles: Role[] }>({
+const memberState = atom<MemberInfo | null>({
   key: 'memberState',
-  default: {
-    roles: [],
-  },
+  default: null,
   effects_UNSTABLE: [persistAtom],
 });
 


### PR DESCRIPTION
## 연관 이슈
- Close #530

## 작업 요약
- 로그인 시 필요한 정보 localstorage에 저장하고 로그인 여부에 따른 헤더 처리해주고 로그아웃 기능 추가하였습니다.

## 작업 상세 설명
- 로그인 성공 시 member atom 값 설정해주는 로직 UI와는 상관없는 부분이라 로그인 컴포넌트 쪽에서 API 쪽으로 옮겼습니다.
- 로그아웃 시 member atom 값 비우고 메인페이지로 이동하도록 처리해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 `7분`
- 프로필 이미지 해당 user에 맞게 띄워주는 거 추가로 처리해야 합니다. 이슈 분리하여 진행 예정입니다 #531 
- ~프로필 이미지 클릭 시 뜨는 계정 정보 이메일이 아닌 아이디로 처리하고 싶은데 로그인 응답으로 아이디는 제공해주지 않아서 백엔드 측과 의논해볼 예정입니다.~ 아이디 받아와 띄워주는 걸로 변경 완료!

## Preview 이미지
<img width="500" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/8d194d9d-3a98-420f-89ed-d786bfee0e60">  <img width="500" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/bc786091-fde2-45f3-b16d-d576001334ba">
