### PR TITLE
Feature/게임 결과 및 보유 포인트 연결 #553

### DIFF
--- a/src/api/gameApi.ts
+++ b/src/api/gameApi.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+
+export const gameKeys = {
+  myInfo: ['myInfo'] as const,
+};
+
+const useGetMyGameInfoQuery = () => {
+  const fetcher = () => axios.get(`game/my-info`).then(({ data }) => data);
+
+  return useQuery<{ todayTotalEarnedPoint: number; currentMemberPoint: number }>(gameKeys.myInfo, fetcher);
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { useGetMyGameInfoQuery };

--- a/src/pages/Game/Baseball/components/NoticeEnd.tsx
+++ b/src/pages/Game/Baseball/components/NoticeEnd.tsx
@@ -1,4 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
+import { gameKeys } from '@api/gameApi';
+import { baseballKeys } from '../api/baseballApi';
+import { GameStatus } from '../api/baseballDto';
 
 export type EndType = 'win' | 'lose';
 
@@ -7,6 +11,17 @@ interface NoticeEndProps {
 }
 
 const NoticeEnd = ({ endType }: NoticeEndProps) => {
+  const queryClient = useQueryClient();
+  const data: { status: GameStatus; baseballPerDay: number } | undefined = queryClient.getQueryData(
+    baseballKeys.status,
+  );
+
+  useEffect(() => {
+    if (!data || data.status === 'END') return;
+
+    queryClient.invalidateQueries(gameKeys.myInfo);
+  }, []);
+
   const msg = {
     win: {
       main: 'congraturation',

--- a/src/pages/Game/Game.tsx
+++ b/src/pages/Game/Game.tsx
@@ -3,14 +3,18 @@ import { Divider, Stack, Typography } from '@mui/material';
 import StandardTab from '@components/Tab/StandardTab';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import ConfirmModal from '@components/Modal/ConfirmModal';
+import { useGetMyGameInfoQuery } from '@api/gameApi';
 import Baseball from './Baseball/Baseball';
 
 const Game = () => {
   const [tab, setTab] = useState(0);
   const [isGameModalOpen, setIsGameModalOpen] = useState(false);
 
-  const point = 29472; // TODO API 받아오기
-  const todayTotalGamePoint = 1214; // TODO API 받아오기
+  const { data: myGameInfo } = useGetMyGameInfoQuery();
+
+  const point = myGameInfo?.currentMemberPoint;
+  const todayTotalGamePoint = myGameInfo?.todayTotalEarnedPoint;
+
   const gameList = [
     {
       id: 1,
@@ -67,17 +71,21 @@ const Game = () => {
         </OutlinedButton>
       </Stack>
       <Stack direction="row" justifyContent="flex-end" className="mb-5">
-        <>
-          <Typography marginRight={0.5}>보유포인트 :</Typography>
-          <Typography className="!font-semibold">{point}</Typography>
-        </>
+        {point !== undefined && (
+          <>
+            <Typography marginRight={0.5}>보유포인트 :</Typography>
+            <Typography className="!font-semibold">{point}</Typography>
+          </>
+        )}
         <Divider className="bg-white" sx={{ marginX: 1, marginY: 0.5 }} orientation="vertical" flexItem />
-        <>
-          <Typography marginRight={0.5}>오늘 결과 :</Typography>
-          <Typography className={`!font-semibold ${todayTotalGamePoint >= 0 ? 'text-pointBlue' : 'text-subRed'}`}>
-            {todayTotalGamePoint}
-          </Typography>
-        </>
+        {todayTotalGamePoint !== undefined && (
+          <>
+            <Typography marginRight={0.5}>오늘 결과 :</Typography>
+            <Typography className={`!font-semibold ${todayTotalGamePoint >= 0 ? 'text-pointBlue' : 'text-subRed'}`}>
+              {todayTotalGamePoint}
+            </Typography>
+          </>
+        )}
       </Stack>
       <Stack className="h-[650px]">{tab === 0 && <Baseball />}</Stack>
       <ConfirmModal


### PR DESCRIPTION
## 연관 이슈
- Close #553

## 작업 요약
- 게임 결과 포인트와 보유 포인트만 연결 및 게임 시작 시 보유 포인트 차감 되는 것과 게임 끝날 시 오늘 결과 및 포인트 바로 반영되도록 처리하였습니다.

## 작업 상세 설명
- 게임 시작 시 보유 포인트 차감은 사용자 입장에서 즉각적인 반영을 위해 api refetch 하는 대신 내부 로직 자체에서 캐싱된 데이터를 업데이트 처리해주는 게 좋을 것 같아서 기존 보유 포인트에서 베팅포인트 빼준 값을 set 해주었습니다.
- 게임 끝날 시에는 보유 포인트와 오늘 결과 다 가져와 반영해야하니 `invalidateQueries` 사용하여 refetch해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 `10분`
- 게임 끝났을 때 보유 포인트 증가되는 게 조금 이상한 것 같아서 백엔드 쪽에 문의 넣어둔 상태입니다! 아래 예시 화면에서 값이 이상하더라도 감안해주세요!

## Preview 영상
(중간에 검은 화면 잠깐 뜨는 건 제 모니터 화면 보호기 잘못켜져서 그런 거라 신경 안써도 됩니다!)

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/387d709b-6331-49ed-a00c-9a3150ac6952

