### PR TITLE
Feature/대출 현황 탭 연체도서 목록 받아오기 #574

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -94,7 +94,7 @@ export interface BorrowInfo {
   bookQuantity: string;
   currentQuantity: number;
   totalQuantity: number;
-  status: '대출대기중' | '반납대기중';
+  status: '대출대기중' | '반납대기중' | '대출거부' | '대출승인' | '반납';
 }
 
 export interface BookInfo {

--- a/src/api/libraryManageApi.ts
+++ b/src/api/libraryManageApi.ts
@@ -6,6 +6,7 @@ import { ManageBookInfo, BookListSearch, BookCoreData, BorrowInfoListSearch, Bor
 const libraryManageKeys = {
   bookManageList: (param: BookListSearch) => ['libraryManage', 'bookManageList', param] as const,
   borrowInfoList: (param: BorrowInfoListSearch) => ['libraryManage', 'borrowInfoList', param] as const,
+  overdueInfoList: (param: BorrowInfoListSearch) => ['libraryManage', 'overdueInfoList', param] as const,
 };
 
 const useGetBookManageListQuery = ({ page, size = 10, searchType, search }: BookListSearch) => {
@@ -53,20 +54,59 @@ const useDeleteBookMutation = () => {
 const useGetBorrowInfoListQuery = ({ page, size = 10, status, search }: BorrowInfoListSearch) => {
   const fetcher = () =>
     axios.get('/manage/borrow-infos', { params: { page, size, status, search } }).then(({ data }) => {
-      const content = data.content.map((borrowInfo: BorrowInfo) => ({
-        borrowInfoId: borrowInfo.borrowInfoId,
-        status: borrowInfo.status === '대출대기중' ? '대출 신청' : '반납 신청',
-        requestDatetime: DateTime.fromISO(borrowInfo?.requestDatetime || '').toFormat('yyyy.MM.dd'),
-        bookTitle: borrowInfo.bookTitle,
-        author: borrowInfo.author,
-        bookQuantity: '3/3', // `${borrowInfo.currentQuantity}/${borrowInfo.totalQuantity}`,
-        borrowerRealName: borrowInfo.borrowerRealName,
-      }));
+      const content = data.content.map((borrowInfo: BorrowInfo) => {
+        let statusFront = '';
+
+        if (borrowInfo.status === '대출대기중') {
+          statusFront = '대출 신청';
+        } else if (borrowInfo.status === '반납대기중') {
+          statusFront = '반납 신청';
+        }
+        return {
+          borrowInfoId: borrowInfo.borrowInfoId,
+          status: statusFront,
+          requestDatetime: DateTime.fromISO(borrowInfo?.requestDatetime || '').toFormat('yyyy.MM.dd'),
+          bookTitle: borrowInfo.bookTitle,
+          author: borrowInfo.author,
+          bookQuantity: '3/3', // `${borrowInfo.currentQuantity}/${borrowInfo.totalQuantity}`,
+          borrowerRealName: borrowInfo.borrowerRealName,
+        };
+      });
       return { content, totalElement: data.totalElements, size: data.size };
     });
 
   return useQuery<{ content: BorrowInfo[]; totalElement: number; size: number }>(
     libraryManageKeys.borrowInfoList({ page, size, status, search }),
+    fetcher,
+  );
+};
+
+const useGetOverdueInfoListQuery = ({ page, size = 10, status = 'overdue' }: BorrowInfoListSearch) => {
+  const fetcher = () =>
+    axios.get('/manage/borrow-infos', { params: { page, size, status } }).then(({ data }) => {
+      const content = data.content.map((borrowInfo: BorrowInfo) => {
+        let statusFront = '';
+
+        if (borrowInfo.status === '대출승인') {
+          statusFront = '대출중';
+        } else if (borrowInfo.status === '반납대기중') {
+          statusFront = '반납대기';
+        }
+
+        return {
+          bookTitle: borrowInfo.bookTitle,
+          author: borrowInfo.author,
+          borrowerRealName: borrowInfo.borrowerRealName,
+          requestDatetime: DateTime.fromISO(borrowInfo?.requestDatetime || '').toFormat('yyyy.MM.dd'),
+          expiredDateTime: DateTime.fromISO(borrowInfo?.expiredDateTime || '').toFormat('yyyy.MM.dd'),
+          status: statusFront,
+        };
+      });
+      return { content, totalElement: data.totalElements, size: data.size };
+    });
+
+  return useQuery<{ content: BorrowInfo[]; totalElement: number; size: number }>(
+    libraryManageKeys.overdueInfoList({ page, size, status }),
     fetcher,
   );
 };
@@ -100,4 +140,5 @@ export {
   useDenyRequestQuery,
   useApproveReturnQuery,
   useDenyReturnQuery,
+  useGetOverdueInfoListQuery,
 };

--- a/src/api/libraryManageApi.ts
+++ b/src/api/libraryManageApi.ts
@@ -55,16 +55,13 @@ const useGetBorrowInfoListQuery = ({ page, size = 10, status, search }: BorrowIn
   const fetcher = () =>
     axios.get('/manage/borrow-infos', { params: { page, size, status, search } }).then(({ data }) => {
       const content = data.content.map((borrowInfo: BorrowInfo) => {
-        let statusFront = '';
-
-        if (borrowInfo.status === '대출대기중') {
-          statusFront = '대출 신청';
-        } else if (borrowInfo.status === '반납대기중') {
-          statusFront = '반납 신청';
-        }
+        const borrowStatus: { [key: string]: string } = {
+          대출대기중: '대출 신청',
+          반납대기중: '반납 신청',
+        };
         return {
           borrowInfoId: borrowInfo.borrowInfoId,
-          status: statusFront,
+          status: borrowStatus[borrowInfo.status],
           requestDatetime: DateTime.fromISO(borrowInfo?.requestDatetime || '').toFormat('yyyy.MM.dd'),
           bookTitle: borrowInfo.bookTitle,
           author: borrowInfo.author,
@@ -85,13 +82,10 @@ const useGetOverdueInfoListQuery = ({ page, size = 10, status = 'overdue' }: Bor
   const fetcher = () =>
     axios.get('/manage/borrow-infos', { params: { page, size, status } }).then(({ data }) => {
       const content = data.content.map((borrowInfo: BorrowInfo) => {
-        let statusFront = '';
-
-        if (borrowInfo.status === '대출승인') {
-          statusFront = '대출중';
-        } else if (borrowInfo.status === '반납대기중') {
-          statusFront = '반납대기';
-        }
+        const borrowStatus: { [key: string]: string } = {
+          대출승인: '대출중',
+          반납대기중: '반납대기',
+        };
 
         return {
           bookTitle: borrowInfo.bookTitle,
@@ -99,7 +93,7 @@ const useGetOverdueInfoListQuery = ({ page, size = 10, status = 'overdue' }: Bor
           borrowerRealName: borrowInfo.borrowerRealName,
           requestDatetime: DateTime.fromISO(borrowInfo?.requestDatetime || '').toFormat('yyyy.MM.dd'),
           expiredDateTime: DateTime.fromISO(borrowInfo?.expiredDateTime || '').toFormat('yyyy.MM.dd'),
-          status: statusFront,
+          status: borrowStatus[borrowInfo.status],
         };
       });
       return { content, totalElement: data.totalElements, size: data.size };

--- a/src/pages/admin/LibraryManage/Modal/OverdueBookModal.tsx
+++ b/src/pages/admin/LibraryManage/Modal/OverdueBookModal.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import { useGetOverdueInfoListQuery } from '@api/libraryManageApi';
+import StandardTable from '@components/Table/StandardTable';
+import usePagination from '@hooks/usePagination';
+import { Column } from '@components/Table/StandardTable.interface';
+
+interface OverdueBookModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface requestManageRow {
+  no: number;
+  bookTitle: string;
+  author: string;
+  borrowerRealName: string;
+  requestDatetime: string | null;
+  expiredDateTime: string | null;
+  status: string;
+}
+
+const requestManageColumn: Column<requestManageRow>[] = [
+  { key: 'no', headerName: '번호' },
+  { key: 'bookTitle', headerName: '도서명' },
+  { key: 'author', headerName: '저자' },
+  { key: 'borrowerRealName', headerName: '대출자' },
+  { key: 'requestDatetime', headerName: '대출 일자' },
+  { key: 'expiredDateTime', headerName: '반납 예정일' },
+  { key: 'status', headerName: '유형' },
+];
+
+const OverdueBookModal = ({ open, onClose }: OverdueBookModalProps) => {
+  const { page, getRowNumber } = usePagination();
+  const { data: overdueInfoListData } = useGetOverdueInfoListQuery({ page });
+
+  if (!overdueInfoListData) return null;
+
+  return (
+    <ConfirmModal open={open} onClose={onClose} title="연체도서" modalWidth="md">
+      <StandardTable
+        columns={requestManageColumn}
+        rows={overdueInfoListData?.content.map((overdueInfo, bookIndex) => ({
+          no: getRowNumber({ size: overdueInfoListData.size, index: bookIndex }),
+          id: overdueInfo?.borrowInfoId,
+          ...overdueInfo,
+        }))}
+        paginationOption={{ rowsPerPage: overdueInfoListData.size, totalItems: overdueInfoListData?.totalElement }}
+      />
+    </ConfirmModal>
+  );
+};
+
+export default OverdueBookModal;

--- a/src/pages/admin/LibraryManage/Modal/OverdueBookModal.tsx
+++ b/src/pages/admin/LibraryManage/Modal/OverdueBookModal.tsx
@@ -11,6 +11,7 @@ interface OverdueBookModalProps {
 }
 
 interface requestManageRow {
+  id: number;
   no: number;
   bookTitle: string;
   author: string;
@@ -41,8 +42,8 @@ const OverdueBookModal = ({ open, onClose }: OverdueBookModalProps) => {
       <StandardTable
         columns={requestManageColumn}
         rows={overdueInfoListData?.content.map((overdueInfo, bookIndex) => ({
-          no: getRowNumber({ size: overdueInfoListData.size, index: bookIndex }),
           id: overdueInfo?.borrowInfoId,
+          no: getRowNumber({ size: overdueInfoListData.size, index: bookIndex }),
           ...overdueInfo,
         }))}
         paginationOption={{ rowsPerPage: overdueInfoListData.size, totalItems: overdueInfoListData?.totalElement }}

--- a/src/pages/admin/LibraryManage/Tab/BorrowingStatusTab.tsx
+++ b/src/pages/admin/LibraryManage/Tab/BorrowingStatusTab.tsx
@@ -1,7 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
+import OutlinedButton from '@components/Button/OutlinedButton';
+
+import OverDueBookModal from '../Modal/OverdueBookModal';
 
 const BorrowingStatusTab = () => {
-  return <>대출 현황</>;
+  const [addBookModalOpen, setAddBookModalOpen] = useState(false);
+
+  return (
+    <>
+      <OutlinedButton onClick={() => setAddBookModalOpen(true)}>연체 도서</OutlinedButton>
+      {addBookModalOpen && <OverDueBookModal open={addBookModalOpen} onClose={() => setAddBookModalOpen(false)} />}
+    </>
+  );
 };
 
 export default BorrowingStatusTab;

--- a/src/pages/admin/LibraryManage/Tab/BorrowingStatusTab.tsx
+++ b/src/pages/admin/LibraryManage/Tab/BorrowingStatusTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import OutlinedButton from '@components/Button/OutlinedButton';
 
-import OverDueBookModal from '../Modal/OverdueBookModal';
+import OverdueBookModal from '../Modal/OverdueBookModal';
 
 const BorrowingStatusTab = () => {
   const [addBookModalOpen, setAddBookModalOpen] = useState(false);
@@ -9,7 +9,7 @@ const BorrowingStatusTab = () => {
   return (
     <>
       <OutlinedButton onClick={() => setAddBookModalOpen(true)}>연체 도서</OutlinedButton>
-      {addBookModalOpen && <OverDueBookModal open={addBookModalOpen} onClose={() => setAddBookModalOpen(false)} />}
+      {addBookModalOpen && <OverdueBookModal open={addBookModalOpen} onClose={() => setAddBookModalOpen(false)} />}
     </>
   );
 };

--- a/src/pages/admin/LibraryManage/Tab/RequestManageTab.tsx
+++ b/src/pages/admin/LibraryManage/Tab/RequestManageTab.tsx
@@ -16,7 +16,6 @@ import { VscCircleLarge, VscChromeClose } from 'react-icons/vsc';
 import RequestManageSearchSection from '../SearchSection/RequestManageSearchSection';
 
 interface requestManageRow {
-  id: number;
   no: number;
   status: string;
   requestDatetime: string | null;


### PR DESCRIPTION
## 연관 이슈
- #570  #573 선행리뷰 부탁드립니다~
- 선행리뷰 머지되면, 코드에 코멘트 달아서 설명하겠습니다

## 작업 요약
- 연체도서 목록 받아와서 띄워줬습니다!
- 대출현황 탭에 테이블 목록 api는 지금 만드는 중이라, 연체도서부터 했습니다!

## 리뷰 요구사항
> 5분

## Preview 이미지
![image](https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/294f3ffd-a208-49c6-9a1c-1e969111e629)