### PR TITLE
Feature/게시판 남은 작업 처리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^17.0.1",
         "react-dropzone": "^14.2.3",
         "react-hook-form": "^7.44.1",
+        "react-hot-toast": "^2.4.1",
         "react-icons": "^4.10.1",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.6.2",
@@ -9012,6 +9013,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -13952,6 +13961,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {
@@ -23532,6 +23556,12 @@
         "slash": "^3.0.0"
       }
     },
+    "goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "requires": {}
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -26911,6 +26941,14 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.1.tgz",
       "integrity": "sha512-6dWoFJwycbuFfw/iKMcl+RdAOAOHDiF11KWYhNDRN/OkUt+Di5qsZHwA0OwsVnu9y135gkHpTw9DJA+WzCeR9w==",
       "requires": {}
+    },
+    "react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "requires": {
+        "goober": "^2.1.10"
+      }
     },
     "react-icons": {
       "version": "4.10.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^17.0.1",
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.44.1",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.10.1",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.6.2",

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -268,6 +268,7 @@ export interface PostSummaryInfo {
   writerThumbnailPath: string;
   visitCount: number;
   commentCount: number;
+  likeCount: number;
   isSecret: boolean;
   thumbnailPath: string;
   registerTime: string;

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 
 import Header from './Header';
 import Sidebar from './Sidebar';
@@ -10,6 +11,7 @@ const MainLayout = () => {
       <Header />
       <Sidebar />
       <Outlet />
+      <Toaster position="top-left" />
     </div>
   );
 };

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -62,7 +62,7 @@ const BoardList = () => {
   const handlePostRowClick = ({ rowData }: { rowData: Row<BoardRow> }) => {
     if (!rowData.id) return;
 
-    navigate(`/board/view/${rowData.id}`);
+    navigate(`/board/view/${rowData.id}`, { state: rowData.isSecret });
   };
 
   const childComponent = ({ key, value, rowData }: ChildComponent<BoardRow>) => {

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -22,6 +22,7 @@ interface BoardRow {
   writerName: string;
   registerTime: string;
   visitCount: number;
+  likeCount: number;
   isSecret: boolean;
 }
 
@@ -31,6 +32,7 @@ const boardColumn: Column<BoardRow>[] = [
   { key: 'writerName', headerName: '작성자' },
   { key: 'registerTime', headerName: '작성일' },
   { key: 'visitCount', headerName: '조회수' },
+  { key: 'likeCount', headerName: '추천수' },
 ];
 
 const BoardList = () => {

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -23,6 +23,7 @@ interface BoardRow {
   registerTime: string;
   visitCount: number;
   likeCount: number;
+  commentCount: number;
   isSecret: boolean;
 }
 
@@ -81,10 +82,14 @@ const BoardList = () => {
         return rowData.isSecret ? (
           <div className="flex items-center">
             <AiFillLock className="mr-1 fill-pointBlue" />
-            비밀글입니다.
+            <span>비밀글입니다.</span>
+            {rowData.commentCount > 0 && <span className="ml-1 text-pointBlue">[{rowData.commentCount}]</span>}
           </div>
         ) : (
-          value
+          <div className="flex items-center">
+            <span>{value}</span>
+            {rowData.commentCount > 0 && <span className="ml-1 text-pointBlue">[{rowData.commentCount}]</span>}
+          </div>
         );
       default:
         return value;

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -79,7 +79,7 @@ const BoardList = () => {
         return rowData.isSecret ? (
           <div className="flex items-center">
             <AiFillLock className="mr-1 fill-pointBlue" />
-            {value}
+            비밀글입니다.
           </div>
         ) : (
           value

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -1,27 +1,44 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useGetEachPostQuery } from '@api/postApi';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import CommentSection from './Section/CommentSection';
 import AdjacentPostNavSection from './Section/AdjacentPostNavSection';
 import PostSection from './Section/PostSection';
 import BannerSection from './Section/BannerSection';
+import SecretPostModal from './Modal/SecretPostModal';
 
 const BoardView = () => {
   const { postId: postIdStr } = useParams();
   const postId = Number(postIdStr);
+  const {
+    state: isSecret,
+  }: {
+    state: boolean | null;
+  } = useLocation();
 
-  const { data: postInfo } = useGetEachPostQuery(postId);
+  const [secretPostModalOpen, setSecretPostModalOpen] = useState(isSecret ?? false);
+  const [password, setPassword] = useState<string>();
 
-  if (!postInfo) return null;
+  const { data: postInfo, isSuccess } = useGetEachPostQuery(postId, isSecret, password);
+
+  useEffect(() => {
+    if (!isSuccess) return;
+    setSecretPostModalOpen(false);
+  }, [isSuccess]);
 
   return (
     <div className="-mt-16 space-y-12">
-      <div className="space-y-2">
-        <BannerSection postId={postId} post={postInfo} />
-        <PostSection postId={postId} post={postInfo} />
-      </div>
-      <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
-      <CommentSection postId={postId} allowComment={postInfo.allowComment} />
+      {postInfo && (
+        <>
+          <div className="space-y-2">
+            <BannerSection postId={postId} post={postInfo} />
+            <PostSection postId={postId} post={postInfo} />
+          </div>
+          <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
+          <CommentSection postId={postId} allowComment={postInfo.allowComment} />
+        </>
+      )}
+      <SecretPostModal setPassword={setPassword} open={secretPostModalOpen} setOpen={setSecretPostModalOpen} />
     </div>
   );
 };

--- a/src/pages/board/BoardView/Modal/SecretPostModal.tsx
+++ b/src/pages/board/BoardView/Modal/SecretPostModal.tsx
@@ -1,0 +1,64 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import StandardInput from '@components/Input/StandardInput';
+import ActionModal from '@components/Modal/ActionModal';
+import { Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+import { POST_PASSWORD_MAX_LENGTH } from '@pages/board/BoardWrite/Modal/SettingUploadModal';
+import { Controller, useForm } from 'react-hook-form';
+
+interface SecretPostModalProps {
+  setPassword: Dispatch<SetStateAction<string | undefined>>;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SecretPostModal = ({ setPassword, open, setOpen }: SecretPostModalProps) => {
+  const navigate = useNavigate();
+
+  const {
+    control,
+    getValues,
+    formState: { isValid },
+  } = useForm({ mode: 'onBlur' });
+
+  const handlePasswordConfirmClick = async () => {
+    setPassword(getValues('password'));
+  };
+
+  return (
+    <ActionModal
+      open={open}
+      onClose={() => {
+        setOpen(false);
+        navigate(-1);
+      }}
+      title="비밀글 보기"
+      actionButtonName="확인"
+      actionButtonDisabled={!isValid}
+      onActionButonClick={handlePasswordConfirmClick}
+    >
+      <Typography>비밀글을 보려면 비밀번호를 입력해주세요.</Typography>
+      <Typography variant="small">(작성자는 확인 버튼만 누르면 됩니다.)</Typography>
+      <div className="my-5 flex justify-center">
+        <Controller
+          name="password"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: REQUIRE_ERROR_MSG,
+            maxLength: {
+              value: POST_PASSWORD_MAX_LENGTH,
+              message: `비밀번호는 최대 ${POST_PASSWORD_MAX_LENGTH}글자 입력이 가능합니다.`,
+            },
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return <StandardInput {...field} type="password" error={Boolean(error)} helperText={error?.message} />;
+          }}
+        />
+      </div>
+    </ActionModal>
+  );
+};
+
+export default SecretPostModal;

--- a/src/pages/board/BoardWrite/Modal/SettingUploadModal.tsx
+++ b/src/pages/board/BoardWrite/Modal/SettingUploadModal.tsx
@@ -7,7 +7,7 @@ import ImageUploader from '@components/Uploader/ImageUploader';
 import { UploadPostSettings } from '@api/dto';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 
-const POST_PASSWORD_MAX_LENGTH = 16;
+export const POST_PASSWORD_MAX_LENGTH = 16;
 
 interface SettingUploadModalProps {
   open: boolean;


### PR DESCRIPTION
## 연관 이슈
- #135 #261 

## 작업 요약
- 비밀글 관련 처리과 테이블에 빠진 요소 추가 해주었습니다.

## 작업 상세 설명
- 비밀글 모달 원래 기획상으론 게시판에서 목록 클릭 시 모달 뜨는 방식인데, API 상으로 비밀번호 확인하는 게 단일 게시글 조회 API 호출 시에 확인이 이루어지는데 게시판에서 해당 API를 확인 용도로 호출하기도 그렇고, 비밀번호 확인용의 API 요청할까 싶기도 했는데 url로 게시글 들어오는 경우에는 비밀번호 입력이 불가할 것 같아서 게시글 조회 쪽에서 처리해주었습니다.
- 비밀글 모달 취소하면 다시 게시판으로 돌아가도록 처리해주었습니다.
- 비밀번호 다를 시에 에러 띄우는 게 까다로운 것 같아서 일단 react-hot-toast 활용하여 toast 메시지로 뜨도록 처리해두었습니다. 일단 다른 급한 작업들 부터 우선적으로 처리하고 와서 더 좋은 방법 있는 지 살펴보겠습니다.

## 리뷰 요구사항
- `7분`
- 아직 게시판 남은 작업 더 있는데 다른 부분 작업하고 돌아올 예정이라 끊어서 PR 올립니다.

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/3243ed78-2ab6-4d5b-98c9-a0c4d3d10937">

<img width="1232" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a3e3099b-1864-46fc-9ff4-d0d68ae99746">
