### PR TITLE
Feature/이미지 업로더 사진 받아오기 #587

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -414,4 +414,3 @@ export interface memberInfo {
   memberName: string;
   generation: string;
 }
-

--- a/src/components/Uploader/ImageUploader.tsx
+++ b/src/components/Uploader/ImageUploader.tsx
@@ -3,9 +3,9 @@ import { useDropzone } from 'react-dropzone';
 import { MdOutlineAddPhotoAlternate } from 'react-icons/md';
 
 import LogoNeon from '@assets/logo/logo_neon.svg';
-import utilApi from '@mocks/UtilApi';
 import WarningModal from '@components/Modal/WarningModal';
 import { Typography } from '@mui/material';
+import { getServerImgUrl } from '@utils/converter';
 
 interface ImageUploaderProps {
   title?: string;
@@ -64,17 +64,7 @@ const ImageUploader = ({ title, isEdit, thumbnailPath, setThumbnail }: ImageUplo
 
   useEffect(() => {
     if (isEdit && thumbnailPath) {
-      const list = thumbnailPath.split('/');
-      const data = utilApi.getThumbnail(list[list.length - 1]);
-      setThumbnail(data);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const base64 = reader.result;
-        if (base64) {
-          setThumbnailBase64(base64.toString);
-        }
-      };
-      reader.readAsDataURL(data);
+      setThumbnailBase64(getServerImgUrl(thumbnailPath));
     }
   }, []);
 


### PR DESCRIPTION
## 연관 이슈
- Close #587

## 작업 요약
- 썸네일 수정 상태일 때 썸네일 경로 전달 시 해당 썸네일 이미지 띄워주도록 처리하였습니다.

## 리뷰 요구사항
- 2분

## Preview 예제 코드
 ```tsx
 <ImageUploader
    isEdit={Boolean(editMode)} // true
    thumbnailPath={editMode?.post.thumbnailPath}
    setThumbnail={setThumbnail}
  />
```
