### PR TITLE
Feature/테이블 높이 줄이기 #130

### DIFF
--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -7,6 +7,7 @@ import { ChildComponent, Column, Row } from './StandardTable.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface StandardTableProps<T extends Record<string, any>> {
+  size?: 'small' | 'medium';
   columns: Column<T>[];
   fixedRows?: Row<T>[];
   rows: Row<T>[];
@@ -17,6 +18,7 @@ interface StandardTableProps<T extends Record<string, any>> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const StandardTable = <T extends Record<string, any>>({
+  size = 'small',
   columns,
   fixedRows,
   rows,
@@ -28,7 +30,7 @@ const StandardTable = <T extends Record<string, any>>({
 
   return (
     <div>
-      <Table>
+      <Table size={size} sx={{ '.MuiTableCell-sizeSmall': { paddingY: '14px' } }}>
         <TableHead className="bg-middleBlack">
           <TableRow>
             {columns.map((column) => (


### PR DESCRIPTION
## 연관 이슈
- #130

## 작업 요약
-  row가 많아졌을 때라거나 테이블 높이가 너무 공간을 많이 차지하는 것 같아서 테이블 높이 조정할 수 있도록 props 추가하고 기본 size small로 처리해주었습니다. 기존 테이블 사이즈 사용하려면 medium 사용하면 됩니다.

## 리뷰 요구사항
- 1분

## Preview 이미지
before
<img width="1487" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/9d22a2bb-c5ae-4bcb-b720-3681b3509deb">

after
<img width="1486" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a78769f0-13c1-409e-9617-179345b2ab39">