### PR TITLE
feat : 도서관리 searchType 초기화되는 문제 해결

### DIFF
--- a/src/pages/admin/LibraryManage/Tab/BookManageTab.tsx
+++ b/src/pages/admin/LibraryManage/Tab/BookManageTab.tsx
@@ -62,7 +62,6 @@ const BookManageTab = () => {
   const handleDeleteButtonClick = (bookId: number) => {
     deleteBookMutation(bookId);
   };
-  if (!bookManageListData) return null;
 
   return (
     <>
@@ -75,18 +74,20 @@ const BookManageTab = () => {
       </div>
       <StandardTable
         columns={libraryManageColumn}
-        rows={bookManageListData?.content.map((book, bookIndex) => ({
-          id: book.bookId,
-          no: getRowNumber({ size: bookManageListData.size, index: bookIndex }),
-          delete: (
-            <IconButton onClick={() => handleDeleteButtonClick(book.bookId)}>
-              <VscTrash size={20} className="fill-subRed" />
-            </IconButton>
-          ),
-          ...book,
-        }))}
+        rows={
+          bookManageListData?.content.map((book, bookIndex) => ({
+            id: book.bookId,
+            no: getRowNumber({ size: bookManageListData.size, index: bookIndex }),
+            delete: (
+              <IconButton onClick={() => handleDeleteButtonClick(book.bookId)}>
+                <VscTrash size={20} className="fill-subRed" />
+              </IconButton>
+            ),
+            ...book,
+          })) || []
+        }
         childComponent={childComponent}
-        paginationOption={{ rowsPerPage: bookManageListData.size, totalItems: bookManageListData?.totalElement }}
+        paginationOption={{ rowsPerPage: bookManageListData?.size, totalItems: bookManageListData?.totalElement }}
         onRowClick={handleBookRowClick}
       />
     </>

--- a/src/pages/admin/LibraryManage/Tab/RequestManageTab.tsx
+++ b/src/pages/admin/LibraryManage/Tab/RequestManageTab.tsx
@@ -53,8 +53,6 @@ const RequestManageTab = () => {
   const { mutate: DenyRequest } = useDenyRequestMutation();
   const { mutate: DenyReturn } = useDenyReturnMutation();
 
-  if (!borrowInfoListData) return null;
-
   const handleActionButtonClick = (action: 'approve' | 'deny', borrowInfoStatus: string, borrowInfoId: number) => {
     let mutateFunction;
 
@@ -76,31 +74,33 @@ const RequestManageTab = () => {
       </div>
       <StandardTable
         columns={requestManageColumn}
-        rows={borrowInfoListData?.content.map((borrowInfo, bookIndex) => ({
-          no: getRowNumber({ size: borrowInfoListData.size, index: bookIndex }),
-          id: borrowInfo.borrowInfoId,
-          requestManageButton: (
-            <>
-              <IconButton
-                onClick={() => {
-                  handleActionButtonClick('approve', borrowInfo.status, borrowInfo.borrowInfoId);
-                }}
-                className="!mr-2 !p-0"
-              >
-                <VscCircleLarge size={16} className="fill-pointBlue" />
-              </IconButton>
-              <IconButton
-                onClick={() => {
-                  handleActionButtonClick('deny', borrowInfo.status, borrowInfo.borrowInfoId);
-                }}
-                className="!p-0"
-              >
-                <VscChromeClose size={16} className="fill-subRed" />
-              </IconButton>
-            </>
-          ),
-          ...borrowInfo,
-        }))}
+        rows={
+          borrowInfoListData?.content.map((borrowInfo, bookIndex) => ({
+            no: getRowNumber({ size: borrowInfoListData.size, index: bookIndex }),
+            id: borrowInfo.borrowInfoId,
+            requestManageButton: (
+              <>
+                <IconButton
+                  onClick={() => {
+                    handleActionButtonClick('approve', borrowInfo.status, borrowInfo.borrowInfoId);
+                  }}
+                  className="!mr-2 !p-0"
+                >
+                  <VscCircleLarge size={16} className="fill-pointBlue" />
+                </IconButton>
+                <IconButton
+                  onClick={() => {
+                    handleActionButtonClick('deny', borrowInfo.status, borrowInfo.borrowInfoId);
+                  }}
+                  className="!p-0"
+                >
+                  <VscChromeClose size={16} className="fill-subRed" />
+                </IconButton>
+              </>
+            ),
+            ...borrowInfo,
+          })) || []
+        }
         paginationOption={{ rowsPerPage: borrowInfoListData?.size, totalItems: borrowInfoListData?.totalElement }}
       />
     </>


### PR DESCRIPTION
## 연관 이슈
- Close #594

## 작업 요약
- 도서, 도서 관리 searchType 초기화되는 문제 해결

## 작업 상세 설명
- **버그** : 검색시, searchType이 초기화되는 문제가 발생함. ex) (도서명) -> 기본 searchType인 (도서명+저자)로 변경됨
- **원인** :  return null 때문에, search section 컴포넌트가 unmount되었다가 mount 되었기 때문에, 이에 useState('도서명 + 저자')인 초기값으로 다시 되버렸기 때문임.
- **해결** : return null 없앰 + StandardTable의 경우 row에 undefined가 들어가면 안되기때문에` || [ ]` 로 값 넣어줌.
-[ 관련 노션 정리 ](https://abrupt-feta-9a9.notion.site/searchType-d386eab14bf64fb8bb1d569c85728f9f?pvs=4)

## 리뷰 요구사항
- 1분
- 버그원인 열심히 찾아봤는데,, 맞는지 확인해주시면 감사하겠씁니다!!
 
