### PR TITLE
Feature/익명 게시판 임시저장 안 되도록 처리 및 안내 문구 띄우기 #595

### DIFF
--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -35,7 +35,7 @@ const BoardView = () => {
             <PostSection postId={postId} post={postInfo} />
           </div>
           <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
-          <CommentSection postId={postId} allowComment={postInfo.allowComment} />
+          <CommentSection categoryName={postInfo.categoryName} postId={postId} allowComment={postInfo.allowComment} />
         </>
       )}
       <SecretPostModal setPassword={setPassword} open={secretPostModalOpen} setOpen={setSecretPostModalOpen} />

--- a/src/pages/board/BoardView/Section/CommentSection.tsx
+++ b/src/pages/board/BoardView/Section/CommentSection.tsx
@@ -7,11 +7,12 @@ import CommentCard from '../Card/CommentCard';
 import CommentWriteCardAction from '../Card/CommentWriteCardAction';
 
 interface CommentSectionProps {
+  categoryName: string;
   allowComment: boolean;
   postId: number;
 }
 
-const CommentSection = ({ allowComment, postId }: CommentSectionProps) => {
+const CommentSection = ({ categoryName, allowComment, postId }: CommentSectionProps) => {
   const [commentContent, setCommentContent] = useState('');
 
   const { data: commentList } = useGetCommentQuery(postId); // TODO postId 정상적으로 받아오지 않을 경우 처리
@@ -63,6 +64,13 @@ const CommentSection = ({ allowComment, postId }: CommentSectionProps) => {
           />
         </CardActions>
       </Card>
+      {categoryName === '익명게시판' && (
+        <div className="flex justify-end">
+          <Typography marginTop={1} variant="small" className="text-subOrange">
+            (*익명 게시판은 댓글 삭제가 불가합니다.)
+          </Typography>
+        </div>
+      )}
     </section>
   );
 };

--- a/src/pages/board/BoardView/Section/CommentSection.tsx
+++ b/src/pages/board/BoardView/Section/CommentSection.tsx
@@ -67,7 +67,7 @@ const CommentSection = ({ categoryName, allowComment, postId }: CommentSectionPr
       {categoryName === '익명게시판' && (
         <div className="flex justify-end">
           <Typography marginTop={1} variant="small" className="text-subOrange">
-            (*익명 게시판은 댓글 삭제가 불가합니다.)
+            *익명 게시판은 댓글 삭제가 불가합니다.
           </Typography>
         </div>
       )}

--- a/src/pages/board/BoardWrite/BoardWrite.tsx
+++ b/src/pages/board/BoardWrite/BoardWrite.tsx
@@ -123,7 +123,7 @@ const BoardWrite = () => {
         <PageTitle>{categoryName}</PageTitle>
         {categoryName === '익명게시판' && (
           <Typography marginLeft={2} lineHeight={5} variant="small" className="text-subOrange">
-            (*익명 게시판은 글 수정/삭제, 임시저장이 불가합니다.)
+            *익명 게시판은 글 수정/삭제, 임시저장이 불가합니다.
           </Typography>
         )}
       </div>

--- a/src/pages/board/BoardWrite/BoardWrite.tsx
+++ b/src/pages/board/BoardWrite/BoardWrite.tsx
@@ -119,7 +119,14 @@ const BoardWrite = () => {
 
   return (
     <div>
-      <PageTitle>{categoryName}</PageTitle>
+      <div className="flex">
+        <PageTitle>{categoryName}</PageTitle>
+        {categoryName === '익명게시판' && (
+          <Typography marginLeft={2} lineHeight={5} variant="small" className="text-subOrange">
+            (*익명 게시판은 글 수정/삭제, 임시저장이 불가합니다.)
+          </Typography>
+        )}
+      </div>
       <div className="mb-5 flex w-full items-center">
         <Stack flexDirection="row" marginRight={4}>
           <Typography fontWeight="semibold" className="!mr-2 pt-1">

--- a/src/pages/board/BoardWrite/BoardWrite.tsx
+++ b/src/pages/board/BoardWrite/BoardWrite.tsx
@@ -168,7 +168,7 @@ const BoardWrite = () => {
         <FileUploader files={files} setFiles={setFiles} />
       </div>
       <div className="flex justify-end space-x-2">
-        {!editMode && (
+        {!editMode && !(categoryName === '익명게시판') && (
           <OutlinedButton onClick={() => handleSaveButtonClick({ isTemp: true })} disabled={!isValid}>
             임시저장
           </OutlinedButton>


### PR DESCRIPTION
## 연관 이슈
- Close #595 

## 작업 요약
- 익명 게시판의 경우 임시저장 못하도록 처리하고, 게시글 수정/삭제, 임시저장, 댓글 삭제 불가하다는 문구 추가해주었습니다.

## 리뷰 요구사항
- 5분
- 문구 배치라거나 색 괜찮나욤?~?

## Preview 이미지
<img width="1489" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/38d32393-ef29-4e9b-bd97-3cb7793bc761">

<img width="1145" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/bff14208-b8d6-40e8-a6d5-d6913401637e">

