### PR TITLE
Feature/게시판 그리드뷰 다듬기

### DIFF
--- a/src/components/Card/FixedPostingCard.tsx
+++ b/src/components/Card/FixedPostingCard.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { IconButton, ImageList, ImageListItem, ImageListItemBar } from '@mui/material';
+import { VscChevronLeft, VscChevronRight } from 'react-icons/vsc';
+import ServerImg from '@components/Image/ServerImg';
+import { Row } from '@components/Table/StandardTable.interface';
+import { CardDetailInfo, CardMainInfo, InteractionScore, PostingCardProps } from './PostingCard';
+
+const NOTICE_VIEW_NUMBER = 3;
+
+const FixedPostingCard = <T,>({
+  fixedRows,
+  onClick,
+}: {
+  fixedRows: (PostingCardProps & Row<T>)[];
+  onClick?: ({ rowData }: { rowData: Row<T> }) => void;
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handlePrevButtonClick = () => {
+    setCurrentIndex((prevIndex) => prevIndex - 1);
+  };
+
+  const handleNextButtonClick = () => {
+    setCurrentIndex((prevIndex) => prevIndex + 1);
+  };
+
+  return (
+    <div className="mb-8 flex justify-center bg-gradient-to-r from-transparent via-middleBlack pb-4 pt-1">
+      <fieldset className="w-fit border-y border-pointBlue">
+        <legend className="mx-auto px-4 font-semibold text-pointBlue">공지</legend>
+        <div className="relative flex items-center justify-center pb-4 pt-1">
+          <ImageList cols={NOTICE_VIEW_NUMBER} gap={30} rowHeight={160}>
+            {fixedRows
+              .slice(currentIndex * NOTICE_VIEW_NUMBER, currentIndex * NOTICE_VIEW_NUMBER + NOTICE_VIEW_NUMBER)
+              .map((row) => (
+                <ImageListItem
+                  key={row.id}
+                  className={`${
+                    onClick ? 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none' : ''
+                  } w-72 bg-middleBlack`}
+                  onClick={onClick ? () => onClick({ rowData: row }) : undefined}
+                >
+                  <ServerImg errorClassName="m-auto h-[118px] w-28" src={row.thumbnailPath ?? ''} alt="게시글 썸네일" />
+                  <ImageListItemBar
+                    className="h-2/5 !bg-transparent !bg-gradient-to-t !from-mainBlack"
+                    title={<CardMainInfo isSecret={row.isSecret} type={row.type} title={row.title} />}
+                    subtitle={
+                      <div className="relative flex h-full items-end justify-between">
+                        <CardDetailInfo
+                          writerThumbnailPath={row.writerThumbnailPath}
+                          writerName={row.writerName}
+                          registerTime={row.registerTime}
+                        />
+                        <InteractionScore
+                          visitCount={row.visitCount}
+                          commentCount={row.commentCount}
+                          likeCount={row.likeCount}
+                        />
+                      </div>
+                    }
+                  />
+                </ImageListItem>
+              ))}
+          </ImageList>
+          {currentIndex !== 0 && (
+            <IconButton
+              onClick={handlePrevButtonClick}
+              color="primary"
+              className="!absolute -left-5 !bg-mainBlack shadow-sm shadow-subBlack"
+            >
+              <VscChevronLeft />
+            </IconButton>
+          )}
+          {fixedRows.length - 1 - NOTICE_VIEW_NUMBER > currentIndex && (
+            <IconButton
+              onClick={handleNextButtonClick}
+              color="primary"
+              className="!absolute -right-5 !bg-mainBlack shadow-sm shadow-subBlack"
+            >
+              <VscChevronRight />
+            </IconButton>
+          )}
+        </div>
+      </fieldset>
+    </div>
+  );
+};
+
+export default FixedPostingCard;

--- a/src/components/Card/FixedPostingCard.tsx
+++ b/src/components/Card/FixedPostingCard.tsx
@@ -30,37 +30,35 @@ const FixedPostingCard = <T,>({
         <legend className="mx-auto px-4 font-semibold text-pointBlue">공지</legend>
         <div className="relative flex items-center justify-center pb-4 pt-1">
           <ImageList cols={NOTICE_VIEW_NUMBER} gap={30} rowHeight={160}>
-            {fixedRows
-              .slice(currentIndex * NOTICE_VIEW_NUMBER, currentIndex * NOTICE_VIEW_NUMBER + NOTICE_VIEW_NUMBER)
-              .map((row) => (
-                <ImageListItem
-                  key={row.id}
-                  className={`${
-                    onClick ? 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none' : ''
-                  } w-72 bg-middleBlack`}
-                  onClick={onClick ? () => onClick({ rowData: row }) : undefined}
-                >
-                  <ServerImg errorClassName="m-auto h-[118px] w-28" src={row.thumbnailPath ?? ''} alt="게시글 썸네일" />
-                  <ImageListItemBar
-                    className="h-2/5 !bg-transparent !bg-gradient-to-t !from-mainBlack"
-                    title={<CardMainInfo isSecret={row.isSecret} type={row.type} title={row.title} />}
-                    subtitle={
-                      <div className="relative flex h-full items-end justify-between">
-                        <CardDetailInfo
-                          writerThumbnailPath={row.writerThumbnailPath}
-                          writerName={row.writerName}
-                          registerTime={row.registerTime}
-                        />
-                        <InteractionScore
-                          visitCount={row.visitCount}
-                          commentCount={row.commentCount}
-                          likeCount={row.likeCount}
-                        />
-                      </div>
-                    }
-                  />
-                </ImageListItem>
-              ))}
+            {fixedRows.slice(currentIndex * NOTICE_VIEW_NUMBER, (currentIndex + 1) * NOTICE_VIEW_NUMBER).map((row) => (
+              <ImageListItem
+                key={row.id}
+                className={`${
+                  onClick ? 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none' : ''
+                } w-72 bg-middleBlack`}
+                onClick={onClick ? () => onClick({ rowData: row }) : undefined}
+              >
+                <ServerImg errorClassName="m-auto h-[118px] w-28" src={row.thumbnailPath ?? ''} alt="게시글 썸네일" />
+                <ImageListItemBar
+                  className="h-2/5 !bg-transparent !bg-gradient-to-t !from-mainBlack"
+                  title={<CardMainInfo isSecret={row.isSecret} type={row.type} title={row.title} />}
+                  subtitle={
+                    <div className="relative flex h-full items-end justify-between">
+                      <CardDetailInfo
+                        writerThumbnailPath={row.writerThumbnailPath}
+                        writerName={row.writerName}
+                        registerTime={row.registerTime}
+                      />
+                      <InteractionScore
+                        visitCount={row.visitCount}
+                        commentCount={row.commentCount}
+                        likeCount={row.likeCount}
+                      />
+                    </div>
+                  }
+                />
+              </ImageListItem>
+            ))}
           </ImageList>
           {currentIndex !== 0 && (
             <IconButton
@@ -71,7 +69,7 @@ const FixedPostingCard = <T,>({
               <VscChevronLeft />
             </IconButton>
           )}
-          {fixedRows.length - 1 - NOTICE_VIEW_NUMBER > currentIndex && (
+          {fixedRows.length > (currentIndex + 1) * NOTICE_VIEW_NUMBER && (
             <IconButton
               onClick={handleNextButtonClick}
               color="primary"

--- a/src/components/Card/PostingCard.interface.ts
+++ b/src/components/Card/PostingCard.interface.ts
@@ -1,6 +1,7 @@
 export interface CardMainInfoProps {
   type?: string;
   title: string;
+  isSecret: boolean;
 }
 
 export interface CardDetailInfoProps {

--- a/src/components/Card/PostingCard.interface.ts
+++ b/src/components/Card/PostingCard.interface.ts
@@ -12,4 +12,5 @@ export interface CardDetailInfoProps {
 export interface InteractionScoreProps {
   visitCount: number;
   commentCount: number;
+  likeCount: number;
 }

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -4,6 +4,7 @@ import { AiFillLock } from 'react-icons/ai';
 import { VscComment, VscEye, VscThumbsup } from 'react-icons/vsc';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { getServerImgUrl } from '@utils/converter';
+import { Row } from '@components/Table/StandardTable.interface';
 import { CardDetailInfoProps, CardMainInfoProps, InteractionScoreProps } from './PostingCard.interface';
 
 export interface PostingCardProps extends CardMainInfoProps, CardDetailInfoProps, InteractionScoreProps {
@@ -58,41 +59,41 @@ const InteractionScore = ({ visitCount, commentCount, likeCount }: InteractionSc
   );
 };
 
-const PostingCard = ({
-  thumbnailPath,
-  type,
-  title,
-  writerThumbnailPath,
-  writerName,
-  registerTime,
-  visitCount,
-  commentCount,
-  likeCount,
-  isSecret,
-}: PostingCardProps) => {
+const PostingCard = <T,>({
+  row,
+  onClick,
+}: {
+  row: PostingCardProps & Row<T>;
+  onClick?: ({ rowData }: { rowData: Row<T> }) => void;
+}) => {
   return (
-    <Card className="w-52 !rounded-none !bg-middleBlack !bg-none">
-      {isSecret && <AiFillLock size={50} className="m-auto h-[118px] fill-pointBlue/30" />}
-      {!isSecret &&
-        (thumbnailPath ? (
+    <Card
+      className={`${
+        onClick ? 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none' : ''
+      } w-52 !rounded-none !bg-middleBlack !bg-none`}
+      onClick={onClick ? () => onClick({ rowData: row }) : undefined}
+    >
+      {row.isSecret && <AiFillLock size={50} className="m-auto h-[118px] fill-pointBlue/30" />}
+      {!row.isSecret &&
+        (row.thumbnailPath ? (
           <CardMedia
             className="h-[118px] bg-middleBlack"
             component="img"
-            src={getServerImgUrl(thumbnailPath)}
+            src={getServerImgUrl(row.thumbnailPath)}
             alt="썸네일"
           />
         ) : (
           <Logo className="m-auto h-[118px] w-28" />
         ))}
       <CardContent className="flex h-24 flex-col justify-between !bg-mainBlack !p-3">
-        <CardMainInfo isSecret={isSecret} type={type} title={title} />
+        <CardMainInfo isSecret={row.isSecret} type={row.type} title={row.title} />
         <div className="relative flex items-end justify-between">
           <CardDetailInfo
-            writerThumbnailPath={writerThumbnailPath}
-            writerName={writerName}
-            registerTime={registerTime}
+            writerThumbnailPath={row.writerThumbnailPath}
+            writerName={row.writerName}
+            registerTime={row.registerTime}
           />
-          <InteractionScore visitCount={visitCount} commentCount={commentCount} likeCount={likeCount} />
+          <InteractionScore visitCount={row.visitCount} commentCount={row.commentCount} likeCount={row.likeCount} />
         </div>
       </CardContent>
     </Card>

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -11,7 +11,7 @@ export interface PostingCardProps extends CardMainInfoProps, CardDetailInfoProps
   thumbnailPath: string | null;
 }
 
-const CardMainInfo = ({ isSecret, type, title }: CardMainInfoProps) => {
+export const CardMainInfo = ({ isSecret, type, title }: CardMainInfoProps) => {
   return (
     <div>
       <Typography className="!-mt-2 h-3 font-medium text-pointBlue" variant="small">
@@ -24,7 +24,7 @@ const CardMainInfo = ({ isSecret, type, title }: CardMainInfoProps) => {
   );
 };
 
-const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardDetailInfoProps) => {
+export const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardDetailInfoProps) => {
   return (
     <div className="flex">
       <Avatar className="mr-2 !h-6 !w-6" src={writerThumbnailPath ?? undefined} />
@@ -40,7 +40,7 @@ const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardD
   );
 };
 
-const InteractionScore = ({ visitCount, commentCount, likeCount }: InteractionScoreProps) => {
+export const InteractionScore = ({ visitCount, commentCount, likeCount }: InteractionScoreProps) => {
   return (
     <div className="absolute bottom-0 right-0 flex space-x-1 text-pointBlue">
       <div className="flex items-center">

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Avatar, Card, CardContent, CardMedia, Stack, Typography } from '@mui/material';
+import { AiFillLock } from 'react-icons/ai';
 import { VscComment, VscEye, VscThumbsup } from 'react-icons/vsc';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { getServerImgUrl } from '@utils/converter';
@@ -9,14 +10,14 @@ export interface PostingCardProps extends CardMainInfoProps, CardDetailInfoProps
   thumbnailPath: string | null;
 }
 
-const CardMainInfo = ({ type, title }: CardMainInfoProps) => {
+const CardMainInfo = ({ isSecret, type, title }: CardMainInfoProps) => {
   return (
     <div>
       <Typography className="!-mt-2 h-3 font-medium text-pointBlue" variant="small">
         {type ?? ''}
       </Typography>
       <Typography className="font-semibold" variant="paragraph">
-        {title}
+        {isSecret ? '비밀글입니다.' : title}
       </Typography>
     </div>
   );
@@ -67,21 +68,24 @@ const PostingCard = ({
   visitCount,
   commentCount,
   likeCount,
+  isSecret,
 }: PostingCardProps) => {
   return (
     <Card className="w-52 !rounded-none !bg-middleBlack !bg-none">
-      {thumbnailPath ? (
-        <CardMedia
-          className="h-[118px] bg-middleBlack"
-          component="img"
-          src={getServerImgUrl(thumbnailPath)}
-          alt="썸네일"
-        />
-      ) : (
-        <Logo className="m-auto h-[118px] w-28" />
-      )}
+      {isSecret && <AiFillLock size={50} className="m-auto h-[118px] fill-pointBlue/30" />}
+      {!isSecret &&
+        (thumbnailPath ? (
+          <CardMedia
+            className="h-[118px] bg-middleBlack"
+            component="img"
+            src={getServerImgUrl(thumbnailPath)}
+            alt="썸네일"
+          />
+        ) : (
+          <Logo className="m-auto h-[118px] w-28" />
+        ))}
       <CardContent className="flex h-24 flex-col justify-between !bg-mainBlack !p-3">
-        <CardMainInfo type={type} title={title} />
+        <CardMainInfo isSecret={isSecret} type={type} title={title} />
         <div className="relative flex items-end justify-between">
           <CardDetailInfo
             writerThumbnailPath={writerThumbnailPath}

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -40,24 +40,18 @@ const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardD
 
 const InteractionScore = ({ visitCount, commentCount, likeCount }: InteractionScoreProps) => {
   return (
-    <div className="flex space-x-1.5 text-pointBlue">
+    <div className="absolute bottom-0 right-0 flex space-x-1 text-pointBlue">
       <div className="flex items-center">
         <VscEye className="mr-0.5 fill-pointBlue" size={12} />
-        <Typography className="!mt-0.5 font-normal" variant="small">
-          {visitCount}
-        </Typography>
+        <Typography variant="small">{visitCount}</Typography>
       </div>
       <div className="flex items-center">
         <VscThumbsup className="mr-0.5 fill-pointBlue" size={12} />
-        <Typography className="!mt-0.5 font-normal" variant="small">
-          {likeCount}
-        </Typography>
+        <Typography variant="small">{likeCount}</Typography>
       </div>
       <div className="flex items-center">
         <VscComment className="mr-0.5 fill-pointBlue" size={12} />
-        <Typography className="!mt-0.5 font-normal" variant="small">
-          {commentCount}
-        </Typography>
+        <Typography variant="small">{commentCount}</Typography>
       </div>
     </div>
   );
@@ -88,7 +82,7 @@ const PostingCard = ({
       )}
       <CardContent className="flex h-24 flex-col justify-between !bg-mainBlack !p-3">
         <CardMainInfo type={type} title={title} />
-        <div className="flex items-end justify-between">
+        <div className="relative flex items-end justify-between">
           <CardDetailInfo
             writerThumbnailPath={writerThumbnailPath}
             writerName={writerName}

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Avatar, Card, CardContent, CardMedia, Stack, Typography } from '@mui/material';
-import { VscComment, VscEye } from 'react-icons/vsc';
+import { VscComment, VscEye, VscThumbsup } from 'react-icons/vsc';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { getServerImgUrl } from '@utils/converter';
 import { CardDetailInfoProps, CardMainInfoProps, InteractionScoreProps } from './PostingCard.interface';
@@ -38,13 +38,19 @@ const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardD
   );
 };
 
-const InteractionScore = ({ visitCount, commentCount }: InteractionScoreProps) => {
+const InteractionScore = ({ visitCount, commentCount, likeCount }: InteractionScoreProps) => {
   return (
     <div className="flex space-x-1.5 text-pointBlue">
       <div className="flex items-center">
         <VscEye className="mr-0.5 fill-pointBlue" size={12} />
         <Typography className="!mt-0.5 font-normal" variant="small">
           {visitCount}
+        </Typography>
+      </div>
+      <div className="flex items-center">
+        <VscThumbsup className="mr-0.5 fill-pointBlue" size={12} />
+        <Typography className="!mt-0.5 font-normal" variant="small">
+          {likeCount}
         </Typography>
       </div>
       <div className="flex items-center">
@@ -66,6 +72,7 @@ const PostingCard = ({
   registerTime,
   visitCount,
   commentCount,
+  likeCount,
 }: PostingCardProps) => {
   return (
     <Card className="w-52 !rounded-none !bg-middleBlack !bg-none">
@@ -87,7 +94,7 @@ const PostingCard = ({
             writerName={writerName}
             registerTime={registerTime}
           />
-          <InteractionScore visitCount={visitCount} commentCount={commentCount} />
+          <InteractionScore visitCount={visitCount} commentCount={commentCount} likeCount={likeCount} />
         </div>
       </CardContent>
     </Card>

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
+import FixedPostingCard from '@components/Card/FixedPostingCard';
 import PostingCard, { PostingCardProps } from '@components/Card/PostingCard';
 import StandardTablePagination from '@components/Pagination/StandardTablePagination';
 import { PaginationOption } from '@components/Pagination/StandardTablePagination.interface';
 import { Row } from './StandardTable.interface';
 
 interface GridTableProps<T> {
+  fixedRows?: (PostingCardProps & Row<T>)[];
   rows: (PostingCardProps & Row<T>)[];
   onRowClick?: ({ rowData }: { rowData: Row<T> }) => void;
   paginationOption?: PaginationOption;
 }
 
-const GridTable = <T,>({ rows, onRowClick, paginationOption }: GridTableProps<T>) => {
+const GridTable = <T,>({ fixedRows, rows, onRowClick, paginationOption }: GridTableProps<T>) => {
   return (
-    <div>
+    <div className="flex flex-col justify-center">
+      {fixedRows && fixedRows.length > 0 && <FixedPostingCard<T> fixedRows={fixedRows} onClick={onRowClick} />}
       <div className="mb-1 grid grid-cols-5 gap-2">
         {rows.map((row) => (
-          <PostingCard<T> row={row} onClick={onRowClick} />
+          <PostingCard<T> key={row.id} row={row} onClick={onRowClick} />
         ))}
       </div>
       <StandardTablePagination {...paginationOption} />

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -6,42 +6,17 @@ import { Row } from './StandardTable.interface';
 
 interface GridTableProps<T> {
   rows: (PostingCardProps & Row<T>)[];
+  onRowClick?: ({ rowData }: { rowData: Row<T> }) => void;
   paginationOption?: PaginationOption;
 }
 
-const GridTable = <T,>({ rows, paginationOption }: GridTableProps<T>) => {
+const GridTable = <T,>({ rows, onRowClick, paginationOption }: GridTableProps<T>) => {
   return (
     <div>
       <div className="mb-1 grid grid-cols-5 gap-2">
-        {rows.map(
-          ({
-            id,
-            thumbnailPath,
-            type,
-            title,
-            writerThumbnailPath,
-            writerName,
-            registerTime,
-            visitCount,
-            commentCount,
-            likeCount,
-            isSecret,
-          }) => (
-            <PostingCard
-              key={id}
-              type={type}
-              title={title}
-              writerThumbnailPath={writerThumbnailPath}
-              writerName={writerName}
-              registerTime={registerTime}
-              visitCount={visitCount}
-              commentCount={commentCount}
-              likeCount={likeCount}
-              thumbnailPath={thumbnailPath}
-              isSecret={isSecret}
-            />
-          ),
-        )}
+        {rows.map((row) => (
+          <PostingCard<T> row={row} onClick={onRowClick} />
+        ))}
       </div>
       <StandardTablePagination {...paginationOption} />
     </div>

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -25,6 +25,7 @@ const GridTable = <T,>({ rows, paginationOption }: GridTableProps<T>) => {
             visitCount,
             commentCount,
             likeCount,
+            isSecret,
           }) => (
             <PostingCard
               key={id}
@@ -37,6 +38,7 @@ const GridTable = <T,>({ rows, paginationOption }: GridTableProps<T>) => {
               commentCount={commentCount}
               likeCount={likeCount}
               thumbnailPath={thumbnailPath}
+              isSecret={isSecret}
             />
           ),
         )}

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -24,6 +24,7 @@ const GridTable = <T,>({ rows, paginationOption }: GridTableProps<T>) => {
             registerTime,
             visitCount,
             commentCount,
+            likeCount,
           }) => (
             <PostingCard
               key={id}
@@ -34,6 +35,7 @@ const GridTable = <T,>({ rows, paginationOption }: GridTableProps<T>) => {
               registerTime={registerTime}
               visitCount={visitCount}
               commentCount={commentCount}
+              likeCount={likeCount}
               thumbnailPath={thumbnailPath}
             />
           ),

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -125,6 +125,10 @@ const BoardList = () => {
       )}
       {tableView === 'Grid' && (
         <GridTable<BoardRow>
+          fixedRows={noticePosts.map((noticePost) => ({
+            no: '공지',
+            ...noticePost,
+          }))}
           rows={posts.content.map((post, postIndex) => ({
             no: getRowNumber({ size: posts.size, index: postIndex }),
             ...post,

--- a/src/pages/board/BoardList/BoardList.tsx
+++ b/src/pages/board/BoardList/BoardList.tsx
@@ -129,6 +129,7 @@ const BoardList = () => {
             no: getRowNumber({ size: posts.size, index: postIndex }),
             ...post,
           }))}
+          onRowClick={handlePostRowClick}
           paginationOption={{ rowsPerPage: posts.size, totalItems: posts.totalElements }}
         />
       )}


### PR DESCRIPTION
## 연관 이슈
- #135, Close #261, Close #556

## 작업 요약
- 그리드 뷰에 처리 안 되어 있던 작업들 해주었습니다.

## 작업 상세 설명
- 추가된 기획 사항으로 추천수 추가해주었습니다.
- 비밀글의 경우 이미지에 자물쇠 이미지와, 제목 `비밀글입니다.` 로 처리해주었습니다.
- 클릭 시 게시글로 이동하도록 처리해주었습니다.
- 공지글 상단에 따로 빼주었고, 공지글이 있는 경우만 공지글 섹션이 뜨도록 처리해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 15분
- 디자인 했던 것에서 덜 구현된 부분이 있는데 일단 기능 돌아가는 게 급한 것 같아서 개발 공수가 덜 드는 방향으로 디자인 적용해두었습니다! 디자인 맞춰 더 다듬는 건 추후 과제로 미뤄둘 예정입니다!

## Preview 이미지
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a2d78900-a503-4a2c-a0c7-f26fff6903ec">
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/23e91244-1a0d-4018-93a7-a875f5c73aa6">
<img width="1728" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/c91dde96-a229-4cd5-9670-175cac9820b3">

