### PR TITLE
Feature/게시글 파일 수정 #597

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -245,6 +245,7 @@ export interface UploadPost {
 
 export interface FileInfo {
   id: number;
+  fileId: number;
   name: string;
   path: string;
   size: number;

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -109,6 +109,29 @@ const useGetNoticePostListQuery = ({ categoryId }: { categoryId: number }) => {
   });
 };
 
+const useAddFilesMutation = () => {
+  const fetcher = ({ postId, files }: { postId: number; files: File[] }) => {
+    const formData = new FormData();
+    files.forEach((file) => formData.append('files', file));
+
+    return axios.post(`/posts/${postId}/files`, formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
+    });
+  };
+
+  return useMutation(fetcher);
+};
+
+const useDeleteFilesMutation = () => {
+  const fetcher = ({ postId, fileIds }: { postId: number; fileIds: number[] }) => {
+    return axios.delete(`/posts/${postId}/files`, { data: { fileIds } });
+  };
+
+  return useMutation(fetcher);
+};
+
 const useGetEachPostQuery = (postId: number, isSecret: boolean | null, password?: string) => {
   const location = useLocation();
 
@@ -187,6 +210,8 @@ export {
   useControlPostLikesMutation,
   useControlPostDislikesMutation,
   useGetNoticePostListQuery,
+  useAddFilesMutation,
+  useDeleteFilesMutation,
   useGetEachPostQuery,
   useGetPostFilesQuery,
   useDownloadFileMutation,

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -137,7 +137,9 @@ const useGetEachPostQuery = (postId: number, isSecret: boolean | null, password?
 };
 
 const useGetPostFilesQuery = (postId: number) => {
-  const fetcher = () => axios.get(`/posts/${postId}/files`).then(({ data }) => data);
+  // TODO API 변경사항 적용
+  const fetcher = () =>
+    axios.get(`/posts/${postId}/files`).then(({ data }) => data.map((file: any) => ({ fileId: file.id, ...file })));
 
   return useQuery<FileInfo[]>(['files', postId], fetcher);
 };
@@ -153,6 +155,7 @@ const useGetTrendPostsQuery = () => {
 
   return useQuery<TrendingPostInfo[]>('trendPosts', fetcher);
 };
+
 const useDownloadFileMutation = () => {
   const fetcher = ({ postId, fileId, fileName }: { postId: number; fileId: number; fileName: string }) =>
     axios

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -137,9 +137,7 @@ const useGetEachPostQuery = (postId: number, isSecret: boolean | null, password?
 };
 
 const useGetPostFilesQuery = (postId: number) => {
-  // TODO API 변경사항 적용
-  const fetcher = () =>
-    axios.get(`/posts/${postId}/files`).then(({ data }) => data.map((file: any) => ({ fileId: file.id, ...file })));
+  const fetcher = () => axios.get(`/posts/${postId}/files`).then(({ data }) => data);
 
   return useQuery<FileInfo[]>(['files', postId], fetcher);
 };

--- a/src/components/Uploader/FileUploadList.tsx
+++ b/src/components/Uploader/FileUploadList.tsx
@@ -4,8 +4,8 @@ import { VscTrash } from 'react-icons/vsc';
 import { formatFileSize } from '@utils/converter';
 
 interface FileUploadListTableProps {
-  files: File[];
-  onDeleteButtonClick: (fileName: string) => void;
+  files: (File & { fileId?: number })[];
+  onDeleteButtonClick: (fileName: string, fileId?: number) => void;
 }
 
 const FileUploadListTable = ({ files, onDeleteButtonClick }: FileUploadListTableProps) => {
@@ -25,7 +25,7 @@ const FileUploadListTable = ({ files, onDeleteButtonClick }: FileUploadListTable
               <TableCell>{file.name}</TableCell>
               <TableCell>{formatFileSize(file.size)}</TableCell>
               <TableCell>
-                <IconButton onClick={() => onDeleteButtonClick(file.name)}>
+                <IconButton onClick={() => onDeleteButtonClick(file.name, file.fileId)}>
                   <VscTrash size={20} className="fill-subRed" />
                 </IconButton>
               </TableCell>

--- a/src/components/Uploader/FileUploader.tsx
+++ b/src/components/Uploader/FileUploader.tsx
@@ -6,24 +6,44 @@ import { VscNewFile } from 'react-icons/vsc';
 import FileUploadListTable from './FileUploadList';
 
 interface FileUploaderProps {
+  existingFiles?: (File & { fileId: number })[];
+  setExistingFiles?: React.Dispatch<React.SetStateAction<(File & { fileId: number })[]>>;
   files: File[];
   setFiles: React.Dispatch<React.SetStateAction<File[]>>;
+  setFileIdsToDelete?: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
-const FileUploader = ({ files, setFiles }: FileUploaderProps) => {
+const FileUploader = ({
+  existingFiles = [],
+  setExistingFiles,
+  files: filesToAdd,
+  setFiles: setFilesToAdd,
+  setFileIdsToDelete,
+}: FileUploaderProps) => {
   const onDrop = (acceptedFiles: File[]) => {
-    setFiles((prevFiles) => [...prevFiles, ...acceptedFiles]);
+    setFilesToAdd((prevFiles) => [...prevFiles, ...acceptedFiles]);
   };
 
   const { getRootProps, isDragActive } = useDropzone({ onDrop });
 
-  const handleDeleteUploadFileClick = (fileName: string) => {
-    setFiles((prevFiles) => prevFiles.filter((file) => file.name !== fileName));
+  const handleDeleteUploadFileClick = (fileName: string, fileId?: number) => {
+    if (fileId && setFileIdsToDelete && setExistingFiles) {
+      setFileIdsToDelete((prevFileIds) => [...prevFileIds, fileId]);
+      setExistingFiles((prevFiles) => prevFiles.filter((file) => file.name !== fileName));
+      return;
+    }
+
+    setFilesToAdd((prevFiles) => prevFiles.filter((file) => file.name !== fileName));
   };
 
   return (
     <div className="space-y-4">
-      {files.length > 0 && <FileUploadListTable files={files} onDeleteButtonClick={handleDeleteUploadFileClick} />}
+      {existingFiles.length + filesToAdd.length > 0 && (
+        <FileUploadListTable
+          files={[...existingFiles, ...filesToAdd]}
+          onDeleteButtonClick={handleDeleteUploadFileClick}
+        />
+      )}
       <div
         {...getRootProps()}
         className={`flex h-28 w-full items-center justify-center border border-dashed border-pointBlue text-pointBlue ${

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -41,7 +41,7 @@ const PostSection = ({ postId, post }: PostSectionProps) => {
       <div className="mb-10 mt-2 flex justify-end gap-3 text-pointBlue">
         {files &&
           files.map((file) => (
-            <Button key={file.id} className="flex" onClick={() => handleDownloadFileClick(file.id, file.name)}>
+            <Button key={file.fileId} className="flex" onClick={() => handleDownloadFileClick(file.fileId, file.name)}>
               <VscFile className="mr-1" size={24} />
               <span>{file.name}</span>
             </Button>

--- a/src/pages/board/BoardWrite/BoardWrite.tsx
+++ b/src/pages/board/BoardWrite/BoardWrite.tsx
@@ -5,7 +5,13 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Stack, Typography } from '@mui/material';
 import { Editor } from '@toast-ui/react-editor';
 import { PostInfo, UploadPostSettings } from '@api/dto';
-import { useEditPostMutation, useEditPostThumbnailMutation, useUploadPostMutation } from '@api/postApi';
+import {
+  useAddFilesMutation,
+  useDeleteFilesMutation,
+  useEditPostMutation,
+  useEditPostThumbnailMutation,
+  useUploadPostMutation,
+} from '@api/postApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { categoryNameToId } from '@utils/converter';
 import OutlinedButton from '@components/Button/OutlinedButton';
@@ -50,6 +56,8 @@ const BoardWrite = () => {
   const { mutate: uploadPostMutation } = useUploadPostMutation();
   const { mutate: editPost } = useEditPostMutation();
   const { mutate: editPostThumbnail } = useEditPostThumbnailMutation();
+  const { mutate: editAddFiles } = useAddFilesMutation();
+  const { mutate: editDeleteFiles } = useDeleteFilesMutation();
   const {
     control,
     getValues,
@@ -80,17 +88,18 @@ const BoardWrite = () => {
         {
           onSuccess: () => {
             if (thumbnail) {
-              editPostThumbnail(
-                { postId: editMode.postId, thumbnail },
-                {
-                  onSuccess: () => {
-                    navigate(`/board/${categoryName}`);
-                  },
-                },
-              );
-            } else {
-              navigate(`/board/${categoryName}`);
+              editPostThumbnail({ postId: editMode.postId, thumbnail });
             }
+
+            if (filesToAdd.length > 0) {
+              editAddFiles({ postId: editMode.postId, files: filesToAdd });
+            }
+
+            if (fileIdsToDelete.length > 0) {
+              editDeleteFiles({ postId: editMode.postId, fileIds: fileIdsToDelete });
+            }
+
+            navigate(`/board/${categoryName}`);
           },
         },
       );


### PR DESCRIPTION
## 연관 이슈
- Close #597

## 작업 요약
- 게시글 파일 수정 기능 구현하였습니다. 

## 작업 상세 설명
- 파일 관리하는 배열에 크게 3가지가 있는데, `추가할 파일`, `이미 있던 파일`, `삭제할 파일`로 관리가 됩니다. API에서 수정 시에 단일 처리가 아닌 추가/삭제 API로 분리되어 있으며 최종적으로 수정 버튼 클릭 시 한 번에 반영되야 하기 때문에 이렇게 각각의 배열로 두는 방식으로 확장을 해주었습니다.
  - `추가할 파일`은 기본적으로 사용하는 배열으로 최종적으로 추가될 파일 배열이며 수정 시에 추가할 파일도 해당 배열에서 관리됩니다.
  - `이미 있던 파일`은 수정 시에 사용한다고 보면 되는데, 서버에 올라가 있는 파일을 받아와 띄워주기 위함입니다. 조회 용도로만 쓰입니다.
  - `삭제할 파일`은 파일 id로 삭제가 이루어 지고 서버에 올라이 있는 파일 대상으로 삭제할 파일 id를 담는 배열입니다.

아래 코멘트로 props별로 설명 추가로 남겨두겠습니다.

## 리뷰 요구사항
- 리뷰 예상 시간 10분
