### PR TITLE
Feature/ServerImg null 일때 api 호출로 인한 콘솔 에러 제거 #509

### DIFF
--- a/src/components/Image/ServerImg.tsx
+++ b/src/components/Image/ServerImg.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import LogoNeon from '@assets/logo/logo_neon.svg';
+import LogoNeon, { ReactComponent as LogoNeonComponent } from '@assets/logo/logo_neon.svg';
 import { getServerImgUrl } from '@utils/converter';
 
 interface ServerImg {
@@ -18,8 +18,10 @@ const ServerImg = ({ src, alt, className, errorClassName }: ServerImg) => {
     setError(true);
   };
 
-  return (
+  return src ? (
     <img src={srcWithServerUrl} alt={alt} onError={handleImgError} className={error ? errorClassName : className} />
+  ) : (
+    <LogoNeonComponent className={errorClassName || ''} />
   );
 };
 


### PR DESCRIPTION
## 연관 이슈
- #509

## 작업 요약
- null 이미지일 때 api 호출 자체를 안 하도록 처리하였습니다.

## 작업 상세 설명
- null 일 때 로고 이미지는 정상적으로 출력하고 있으나, 콘솔에 에러 문구 뜨는 게 거슬려서 null일 때 호출 안 하도록 조건부로 처리해주었습니다.

## 리뷰 요구사항
- 1분
- null이 아니라 서버 경로 오류로 대체 텍스트 뜨는 것도 대체 이미지(로고)로 뜨도록 처리할 예정인데 #619 에서 처리 예정입니다!
