### PR TITLE
Feature/삭제된 댓글 아래 여백 없도록 처리 #608

### DIFF
--- a/src/pages/board/BoardView/Card/CommentCard.tsx
+++ b/src/pages/board/BoardView/Card/CommentCard.tsx
@@ -14,14 +14,16 @@ const CommentCard = ({ commentInfo, replyComments }: CommentCardProps) => {
   return (
     <Card className="!bg-mainBlack !bg-none">
       <CommentCardHeader commentInfo={commentInfo} />
-      <CardContent className="mb-5 !px-16">
-        {!commentInfo.isDeleted && <Typography marginBottom={5}>{commentInfo.content}</Typography>}
-        <div className="space-y-3">
-          {replyComments.map((replyComment) => (
-            <ReplyCard key={replyComment.commentId} commentInfo={replyComment} />
-          ))}
-        </div>
-      </CardContent>
+      {(!commentInfo.isDeleted || replyComments.length > 0) && (
+        <CardContent className="mb-5 !px-16">
+          {!commentInfo.isDeleted && <Typography marginBottom={5}>{commentInfo.content}</Typography>}
+          <div className="space-y-3">
+            {replyComments.map((replyComment) => (
+              <ReplyCard key={replyComment.commentId} commentInfo={replyComment} />
+            ))}
+          </div>
+        </CardContent>
+      )}
       {!commentInfo.isDeleted && <CommentCardFooter commentInfo={commentInfo} />}
     </Card>
   );


### PR DESCRIPTION
## 연관 이슈
- Close #608

## 작업 요약
- 삭제된 댓글에 대댓글 없을 경우 헤더만 남도록 처리하였습니다. (Preview 이미지 참고)

## 리뷰 요구사항
- 1분

## Preview 이미지
|Before|After|
|------|------|
|<img width="1109" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/d7c6cd24-3849-4dfd-b163-7386e80ccd2c">|<img width="1109" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/3a2dcbb1-34d2-406c-83cc-9f9d64c5807d">
|
