### PR TITLE
Feature/헤더 메뉴에 프로필 경로 이동 기능 구현 #632

### DIFF
--- a/src/components/Layout/Header/Menu/AccountMenu.tsx
+++ b/src/components/Layout/Header/Menu/AccountMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Divider, Menu, MenuItem, MenuList } from '@mui/material';
 import { useSignOutMutation } from '@api/authApi';
 import { MemberInfo } from '@api/dto';
@@ -11,7 +12,12 @@ interface AccountMenuProps {
 }
 
 const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) => {
+  const navigate = useNavigate();
   const { mutate: logout } = useSignOutMutation();
+
+  const handleProfileClick = () => {
+    navigate('profile');
+  };
 
   const handleLogOutClick = () => {
     logout();
@@ -21,7 +27,9 @@ const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) =>
     <Menu anchorEl={anchorEl} open={open} onClose={onClose}>
       <MenuList className="text-center">{userInfo.loginId}</MenuList>
       <Divider className="!my-1" />
-      <MenuItem className="min-w-[150px]">프로필</MenuItem>
+      <MenuItem className="min-w-[150px]" onClick={handleProfileClick}>
+        프로필
+      </MenuItem>
       <MenuItem className="min-w-[150px]" onClick={handleLogOutClick}>
         로그아웃
       </MenuItem>


### PR DESCRIPTION
## 연관 이슈
- Close #632

## 작업 요약
- useNavigate 사용하여 헤더 메뉴 프로필 버튼 클릭 시 페이지 이동 되도록 처리하였습니다.

## 리뷰 요구사항
- 예상 소요 시간 1분

## Preview 이미지

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/0c209395-21cf-4c67-9d98-90274af4d826

