### PR TITLE
feat : StandardDatePicker 배경색 확장 및 UI 개선

### DIFF
--- a/src/components/DatePicker/StandardDatePicker.tsx
+++ b/src/components/DatePicker/StandardDatePicker.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { TextField } from '@mui/material';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
@@ -9,19 +8,31 @@ interface StandardDatePickerProps {
   date: DateTime | null;
   setDate: React.Dispatch<React.SetStateAction<DateTime | null>>;
   label?: string;
+  hasBackground?: boolean;
 }
 
-const StandardDatePicker = ({ date, setDate, label }: StandardDatePickerProps) => {
+const StandardDatePicker = ({ date, setDate, label, hasBackground }: StandardDatePickerProps) => {
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <DatePicker
         label={label}
         inputFormat="yyyy.MM.dd"
+        OpenPickerButtonProps={{ size: 'small', color: 'primary' }}
         value={date}
         onChange={(newValue) => {
           setDate(newValue);
         }}
-        renderInput={(params) => <TextField variant="standard" {...params} />}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            variant="standard"
+            InputProps={{
+              className: `before:!border-pointBlue pr-1 ${hasBackground ? 'bg-subGray/5 h-12' : ''}`,
+              ...params.InputProps,
+            }}
+            sx={hasBackground ? { '.MuiFormLabel-root[data-shrink=false]': { top: 8 } } : undefined}
+          />
+        )}
       />
     </LocalizationProvider>
   );

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Stack } from '@mui/material';
+import { DateTime } from 'luxon';
+import StandardDatePicker from '@components/DatePicker/StandardDatePicker';
 
 import StandardInput from '@components/Input/StandardInput';
 
 const SignUpSecondInputSection = () => {
+  const [date, setDate] = useState<DateTime | null>(null);
   return (
     <Stack spacing={2}>
       <Stack spacing={2} direction="row" justifyContent="space-between">
@@ -35,6 +38,7 @@ const SignUpSecondInputSection = () => {
         }}
       />
       {/* TODO "생일 DatePicker" */}
+      <StandardDatePicker hasBackground label="test" date={date} setDate={setDate} />
     </Stack>
   );
 };


### PR DESCRIPTION
## 연관 이슈
- #296. Close #388

## 작업 요약
- 회원가입 페이지에 사용될 배경색 datepicker를 위해 StandardDatepicker 확장해주고, UI도 조금 다듬어주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 5분
- Datepicker `renderInput`으로 `StandardInput` 넣고 싶었는데 `value` 타입이 `string`이어야 하는데 `unknown` 보냈다는 타입 에러가 나서 `String(params.value`)로 형변환도 해보고 `params.value as string`으로 타입 강제도 해보았는데 계속 `unknown`이라 뜨더라구요! 그래서 일단 `TextField` 컴포넌트 사용했습니다! 관련해서 해결 방법 알고 있으신 분 있으면 코멘트 부탁드립니다!
  <img width="451" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/599b9823-fc2e-4ede-9ce2-0ccde60abb43">


## Preview 이미지
`hasBackground === false`
|UI 개선 전|UI 개선 후|
|------|------|
|<img width="367" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/f10d6bac-8b44-4cdb-a884-60b75f35ce70">|<img width="368" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/e16f5620-4d54-40d1-8ebb-b07c520779ed">|

`hasBackground === true`
<img width="533" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/aa1a8fda-ea63-4df7-8c2b-7dcbb0d601d1">
