### PR TITLE
fix : 메뉴를 통한 경로 이동 시에 에러 발생하지 않도록 메뉴창 닫아주도록 처리

### DIFF
--- a/src/components/Layout/Header/Menu/AccountMenu.tsx
+++ b/src/components/Layout/Header/Menu/AccountMenu.tsx
@@ -17,10 +17,12 @@ const AccountMenu = ({ userInfo, anchorEl, open, onClose }: AccountMenuProps) =>
 
   const handleProfileClick = () => {
     navigate('profile');
+    onClose();
   };
 
   const handleLogOutClick = () => {
     logout();
+    onClose();
   };
 
   return (


### PR DESCRIPTION
## 연관 이슈
- Close #544, Close #633

## 작업 상세 설명
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a366c348-b2f2-4efd-b3fa-ed9f2d91a235">
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/fb63486e-d37c-41fc-a5e9-311c31b63371">

- 위의 이미지 같이 헤더 메뉴를 통한 로그아웃 -> 로그인 -> 메인페이지로 이동 할때 좌측 상단에 메뉴창이 뜨면서 anchorEl 관련 에러가 발생하는 이슈가 있었습니다.
- anchorEl가 참조하는 요소를 이동하면서 찾지못해 발생한 에러로 보여져서 헤더 메뉴를 통한 이동 시 메뉴가 닫히도록 처리하여 anchorEl 참조를 끊어줄 수 있도록 처리해주었습니다.

## 리뷰 요구사항
- 1분
