### PR TITLE
Feature/인풋 자동 완성 시 배경색 안 들어가도록 처리 #648

### DIFF
--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -39,6 +39,7 @@ const muiTheme = createTheme({
         root: {
           input: {
             colorScheme: 'dark',
+            WebkitBackgroundClip: 'text !important',
           },
         },
       },

--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -34,6 +34,15 @@ const muiTheme = createTheme({
         },
       },
     },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          input: {
+            colorScheme: 'dark',
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## 연관 이슈
- Close #648

## 작업 상세 설명
- 인풋 자동 완성 시 배경색 안 들어가도록 처리하였습니다. 브라우저 별로는 테스트 못해봤는데 크롬에서는 잘 동작합니다. 다른 브라우저에서 잘 적용 안 될 경우 고려하여 다크 테마일 때의 배경색도 같이 처리해주었습니다.

## 리뷰 요구사항
- 1분

## Preview 이미지
이전 상태
<img width="587" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/4f50b49b-152c-4ea3-a6f8-972c908875cb">

->
다크 테마 적용
<img width="565" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/f6e46a80-121c-44c7-b0d5-c8133f5b28aa">

->
현재 상태
<img width="532" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/efee84b0-5f31-4657-b83e-baeb9ee9faae">
