### PR TITLE
Feature/AutoComplete 컴포넌트 개선 #615

### DIFF
--- a/src/components/Input/AutoComplete.tsx
+++ b/src/components/Input/AutoComplete.tsx
@@ -1,26 +1,30 @@
 import React from 'react';
 import { Autocomplete, Chip, TextField } from '@mui/material';
 
-export interface Item {
+interface AutoCompleteItem {
   value: unknown;
   label: string;
   fixed?: boolean;
   group?: string;
 }
 
-export type AutoCompleteValueType = Array<Item> | Item | null;
+export type SingleAutoCompleteValue = AutoCompleteItem | null;
+export type MultiAutoCompleteValue = Array<AutoCompleteItem>;
 
-interface AutoCompleteProps {
-  items?: Array<Item>;
-  value: Array<Item> | Item | null;
-  onChange?: (value: Array<Item> | Item | null) => void;
-  multiple?: boolean;
+type MultiOnChangeFuncType = (value: MultiAutoCompleteValue) => void;
+type SingleOnChangeFuncType = (value: SingleAutoCompleteValue) => void;
+
+interface AutoCompleteProps<Multiple> {
+  items?: Array<AutoCompleteItem>;
+  value: Multiple extends true ? MultiAutoCompleteValue : SingleAutoCompleteValue;
+  multiple?: Multiple;
+  onChange?: Multiple extends true ? MultiOnChangeFuncType : SingleOnChangeFuncType;
   grouped?: boolean;
   placeholder?: string;
   className?: string;
 }
 
-const AutoComplete = ({
+const AutoComplete = <Multiple extends boolean | undefined = false>({
   items = [],
   value,
   onChange = () => {
@@ -30,15 +34,12 @@ const AutoComplete = ({
   grouped = false,
   placeholder = '',
   className = '',
-}: AutoCompleteProps) => {
-  const superOnChange = (v: Array<Item> | Item | null) => {
-    if (multiple) {
-      const fixed = items.filter((item) => item.fixed);
-      const nonFixed = (v as Array<Item>).filter((item) => !item?.fixed);
-      onChange([...fixed, ...nonFixed]);
-    } else {
-      onChange(v);
-    }
+}: AutoCompleteProps<Multiple>) => {
+  const singleSuperOnChange = (v: SingleAutoCompleteValue) => (onChange as SingleOnChangeFuncType)(v);
+  const multiSuperOnChange = (v: MultiAutoCompleteValue) => {
+    const fixed = items.filter((item) => item.fixed);
+    const nonFixed = v.filter((item) => !item?.fixed);
+    (onChange as MultiOnChangeFuncType)([...fixed, ...nonFixed]);
   };
 
   return (
@@ -46,7 +47,10 @@ const AutoComplete = ({
       className={className}
       options={items}
       value={value}
-      onChange={(e, v) => superOnChange(v)}
+      onChange={(e, v) =>
+        multiple ? multiSuperOnChange(v as MultiAutoCompleteValue) : singleSuperOnChange(v as SingleAutoCompleteValue)
+      }
+      isOptionEqualToValue={(option, v) => option.value === v.value}
       multiple={multiple}
       groupBy={(option) => (grouped ? option.group || 'etc' : '')}
       renderInput={(params) => <TextField {...params} variant="standard" placeholder={placeholder} />}

--- a/src/components/Input/AutoComplete.tsx
+++ b/src/components/Input/AutoComplete.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Autocomplete, Chip, TextField } from '@mui/material';
 
 interface AutoCompleteItem {
@@ -42,6 +42,12 @@ const AutoComplete = <Multiple extends boolean | undefined = false>({
     (onChange as MultiOnChangeFuncType)([...fixed, ...nonFixed]);
   };
 
+  useEffect(() => {
+    if (multiple) {
+      multiSuperOnChange([]);
+    }
+  }, []);
+
   return (
     <Autocomplete
       className={className}
@@ -59,6 +65,12 @@ const AutoComplete = <Multiple extends boolean | undefined = false>({
           <Chip label={option.label} {...getTagProps({ index })} disabled={option?.fixed} className="!-z-10" />
         ))
       }
+      renderOption={(props, option) => (
+        <li key={`${option.label}_${option.value}`} {...props}>
+          {option.label}
+          {option?.fixed && <span className="text-xs text-gray-400"> (기본값)</span>}
+        </li>
+      )}
     />
   );
 };

--- a/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
+++ b/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
@@ -6,7 +6,7 @@ import {
   useCreateExecutiveJobMutation,
   useDeleteExecutiveJobMutation,
 } from '@api/dutyManageApi';
-import AutoComplete, { AutoCompleteValueType } from '@components/Input/AutoComplete';
+import AutoComplete, { SingleAutoCompleteValue } from '@components/Input/AutoComplete';
 import ActionModal from '@components/Modal/ActionModal';
 
 interface ChangeRolePersonModalProps {
@@ -43,7 +43,7 @@ const ChangeRolePersonModal = ({ open, toggleOpen, jobName, badgeImage }: Change
   memberList?.forEach((data) => options.push({ value: data.memberId, label: data.realName, group: data.generation }));
   const sortedOptions = options.sort((a, b) => (a.group > b.group ? 1 : -1));
 
-  const [value, setValue] = useState<AutoCompleteValueType>(null);
+  const [value, setValue] = useState<SingleAutoCompleteValue>(null);
   const [prevInfo, setPrevInfo] = useState<{ value: number; label: string; group: string }>({
     value: -1,
     label: '',

--- a/src/pages/admin/MeritManage/Modal/AddMeritModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/AddMeritModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Typography } from '@mui/material';
 import { useGetMemberInfoQuery } from '@api/dutyManageApi';
 import { useAddMeritLogMutation, useGetMeritTypeQuery } from '@api/meritApi';
-import AutoComplete, { AutoCompleteValueType } from '@components/Input/AutoComplete';
+import AutoComplete, { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
 import ActionModal from '@components/Modal/ActionModal';
 import Selector from '@components/Selector/Selector';
 
@@ -12,7 +12,7 @@ interface AddMeritModalProps {
 }
 
 type MeritInfo = {
-  awarders: AutoCompleteValueType;
+  awarders: MultiAutoCompleteValue;
   meritTypeId: number;
 };
 
@@ -34,14 +34,14 @@ const AddMeritModal = ({ open, onClose }: AddMeritModalProps) => {
   };
 
   const validate = () => {
-    return (meritInfo.awarders as Array<unknown>).length > 0 && meritInfo.meritTypeId !== 0;
+    return meritInfo.awarders.length > 0 && meritInfo.meritTypeId !== 0;
   };
 
   const handleAddMeritButtonClick = () => {
     const isValid = validate();
     if (isValid) {
       Promise.all(
-        (meritInfo.awarders as Array<any>).map((awarder) =>
+        meritInfo.awarders.map((awarder) =>
           addMeritMutation({
             awarderId: awarder.value as number,
             meritTypeId: meritInfo.meritTypeId,


### PR DESCRIPTION
## 연관 이슈
#615 

## 작업 요약
AutoComplete 공통컴포넌트 수정했습니다.

## 작업 상세 설명
- Item 대신 AutoCompleteItem으로 변경했습니다
- SingleAutoCompleteValue, MultiAutoCompleteValue 타입을 export 해서 useState에 넣을수 있도록 했습니다
- 제네릭 타입을 사용해서 multiple 여부에 따라 value의 타입이 바뀌도록 했습니다. 이제 value를 as 로 타입변경 할 필요가 없어졌습니다
- 라벨 중복시 key가 겹치는 현상을 수정했습니다. key 값을 label_value로 바꿨습니다. label과 value 모두 같은 경우는 AutoComplete에 둘다 동시에 들어가면 안된다고 생각하여 key 겹치는걸 고려하지 않았습니다
- multiple 일때 처음엔 fixed 값이 뜨지않는 문제를 수정했습니다

## 리뷰 요구사항
> 5분

타입문제를 위주로 작업하였습니다. 실제로 적용했을때 타입 문제가 있거나 관련해서 좋은 아이디어 있으면 알려주세요
