### PR TITLE
Feature/상벌점 페이지 회원별조회 #652

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -443,6 +443,28 @@ export interface MeritType {
   empty: boolean;
 }
 
+export interface MembersMeritInfo {
+  memberId: number;
+  memberName: string;
+  generation: string;
+  merit: number;
+  demerit: number;
+}
+
+export interface MembersMerit {
+  content: MembersMeritInfo[];
+  pageable: PageableInfo;
+  first: boolean;
+  last: boolean;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number;
+  sort: PageSortInfo;
+  numberOfElements: number;
+  empty: boolean;
+}
+
 export interface ExecutiveInfo {
   jobId: number;
   jobName: string;

--- a/src/api/meritApi.ts
+++ b/src/api/meritApi.ts
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import axios from 'axios';
-import { PageAndSize, MeritLog, MeritType } from './dto';
+import { PageAndSize, MeritLog, MeritType, MembersMerit } from './dto';
 
 const meritKeys = {
   meritLog: (param: PageAndSize) => ['meritLog', param] as const,
   meritType: (param: PageAndSize) => ['meritType', param] as const,
+  membersMerit: (param: PageAndSize) => ['membersMerit', param] as const,
 };
 
 const useGetMeritLogQuery = ({ page, size = 10 }: PageAndSize) => {
@@ -29,6 +30,19 @@ const useGetMeritTypeQuery = ({ page, size = 10 }: PageAndSize) => {
       .then(({ data }) => data);
 
   return useQuery<MeritType>(meritKeys.meritType({ page, size }), fetcher, {
+    keepPreviousData: true,
+  });
+};
+
+const useGetMembersMeritQuery = ({ page, size = 10 }: PageAndSize) => {
+  const fetcher = () =>
+    axios
+      .get('/merits/members', {
+        params: { page, size },
+      })
+      .then(({ data }) => data);
+
+  return useQuery<MembersMerit>(meritKeys.membersMerit({ page, size }), fetcher, {
     keepPreviousData: true,
   });
 };
@@ -75,6 +89,7 @@ const useEditMeritTypeMutation = () => {
 export {
   useGetMeritLogQuery,
   useGetMeritTypeQuery,
+  useGetMembersMeritQuery,
   useAddMeritLogMutation,
   useAddMeritTypeMutation,
   useEditMeritTypeMutation,

--- a/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
@@ -1,7 +1,78 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Typography } from '@mui/material';
+import { useGetMembersMeritQuery } from '@api/meritApi';
+import usePagination from '@hooks/usePagination';
+import Selector from '@components/Selector/Selector';
+import StandardTable from '@components/Table/StandardTable';
+import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
+
+interface MembersMeritRow {
+  id: number;
+  memberId: number;
+  memberName: string;
+  generation: string;
+  merit: number;
+  demerit: number;
+}
+
+const MembersMeritColumn: Column<MembersMeritRow>[] = [
+  { key: 'id', headerName: '번호' },
+  { key: 'generation', headerName: '기수' },
+  { key: 'memberName', headerName: '이름' },
+  { key: 'merit', headerName: '상점' },
+  { key: 'demerit', headerName: '벌점' },
+];
+
+const MembersMeritChildComponent = ({ key, value }: ChildComponent<MembersMeritRow>) => {
+  switch (key) {
+    case 'generation':
+      return `${parseFloat(value as string)} 기`;
+    case 'merit':
+      return <Typography className={`${(value as number) > 0 && 'text-pointBlue'}`}>{value}</Typography>;
+    case 'demerit':
+      return <Typography className={`${(value as number) < 0 && 'text-subRed'}`}>{value}</Typography>;
+    default:
+      return value;
+  }
+};
+
+type SortType = 'highestReword' | 'highestPenalty';
 
 const UserMeritTab = () => {
-  return null;
+  const { page, getRowNumber } = usePagination();
+  const [sortType, setSortType] = useState<SortType>('highestReword');
+
+  const { data: membersMerit } = useGetMembersMeritQuery({ page });
+
+  if (!membersMerit) return null;
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="my-5 flex h-12 w-full justify-between">
+        <Selector
+          className="w-40"
+          label="정렬"
+          value={sortType}
+          onChange={(e) => {
+            setSortType(e.target.value as SortType);
+          }}
+          options={[
+            { id: 'highestReword', content: '상점 높은 순' },
+            { id: 'highestPenalty', content: '벌점 높은 순' },
+          ]}
+        />
+      </div>
+      <StandardTable<MembersMeritRow>
+        columns={MembersMeritColumn}
+        rows={membersMerit.content.map((member, index) => ({
+          id: getRowNumber({ size: membersMerit.size, index }),
+          ...member,
+        }))}
+        childComponent={MembersMeritChildComponent}
+        paginationOption={{ rowsPerPage: membersMerit.size, totalItems: membersMerit.totalElements }}
+      />
+    </div>
+  );
 };
 
 export default UserMeritTab;


### PR DESCRIPTION
## 연관 이슈
#652 
#653 머지된 이후에 작업할 이슈입니다

## 작업 요약
상벌점 페이지의 회원별조회 탭입니다

## 작업 상세 설명
회원별 조회 탭입니다.
모달은 따로 PR 올리겠습니다

## 리뷰 요구사항
5분
정렬같은 경우는 프론트에서 처리할수 없을 듯 하여 백엔드에 요청했습니다...

## Preview 이미지
<img width="1214" alt="스크린샷 2023-09-12 오후 5 02 57" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/51306225/7831bac9-5388-4a7f-a818-b960628fcfe9">

