### PR TITLE
Feature/프로필 작성글탭 #642

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -418,3 +418,49 @@ export interface memberInfo {
   memberName: string;
   generation: string;
 }
+
+export interface MemberPostInfo {
+  id: number;
+  title: string;
+  categoryId: number;
+  categoryName: string;
+  visitCount: number;
+  isSecret: boolean;
+  registerTime: string;
+}
+
+export interface MemberPost {
+  content: MemberPostInfo[];
+  pageable: PageableInfo;
+  first: boolean;
+  last: boolean;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number;
+  sort: PageSortInfo;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+export interface MemberTempPostInfo {
+  id: number;
+  title: string;
+  categoryId: number;
+  categoryName: string;
+  registerTime: string;
+}
+
+export interface MemberTempPost {
+  content: MemberTempPostInfo[];
+  pageable: PageableInfo;
+  first: boolean;
+  last: boolean;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number;
+  sort: PageSortInfo;
+  numberOfElements: number;
+  empty: boolean;
+}

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -12,7 +12,14 @@ import {
   UploadPost,
   UploadPostCore,
   TrendingPostInfo,
+  PageAndSize,
+  MemberPost,
 } from './dto';
+
+const postKeys = {
+  memberPost: (param: PageAndSize) => ['memberPost', param] as const,
+  memberTempPost: (param: PageAndSize) => ['memberTempPost', param] as const,
+};
 
 const useUploadPostMutation = () => {
   const fetcher = ({ request, thumbnail, files }: UploadPost) => {
@@ -199,6 +206,22 @@ const useDownloadFileMutation = () => {
   });
 };
 
+const useGetMemberPostsQuery = ({ page, size = 10 }: PageAndSize) => {
+  const fetcher = () => axios.get('/posts/members', { params: { page, size } }).then(({ data }) => data);
+
+  return useQuery<MemberPost>(postKeys.memberPost({ page, size }), fetcher, {
+    keepPreviousData: true,
+  });
+};
+
+const useGetMemberTempPostsQuery = ({ page, size = 10 }: PageAndSize) => {
+  const fetcher = () => axios.get('/posts/members/temp', { params: { page, size } }).then(({ data }) => data);
+
+  return useQuery<MemberPost>(postKeys.memberTempPost({ page, size }), fetcher, {
+    keepPreviousData: true,
+  });
+};
+
 export {
   useUploadPostMutation,
   useGetPostListQuery,
@@ -215,4 +238,6 @@ export {
   useGetEachPostQuery,
   useGetPostFilesQuery,
   useDownloadFileMutation,
+  useGetMemberPostsQuery,
+  useGetMemberTempPostsQuery,
 };

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -17,7 +17,7 @@ import {
 } from './dto';
 
 const postKeys = {
-  memberPost: (param: PageAndSize) => ['memberPost', param] as const,
+  memberPost: (param: PageAndSize & { memberId: number }) => ['memberPost', param] as const,
   memberTempPost: (param: PageAndSize) => ['memberTempPost', param] as const,
 };
 
@@ -206,10 +206,10 @@ const useDownloadFileMutation = () => {
   });
 };
 
-const useGetMemberPostsQuery = ({ page, size = 10 }: PageAndSize) => {
-  const fetcher = () => axios.get('/posts/members', { params: { page, size } }).then(({ data }) => data);
+const useGetMemberPostsQuery = ({ page, size = 10, memberId }: PageAndSize & { memberId: number }) => {
+  const fetcher = () => axios.get(`/posts/members/${memberId}`, { params: { page, size } }).then(({ data }) => data);
 
-  return useQuery<MemberPost>(postKeys.memberPost({ page, size }), fetcher, {
+  return useQuery<MemberPost>(postKeys.memberPost({ page, size, memberId }), fetcher, {
     keepPreviousData: true,
   });
 };

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -215,7 +215,7 @@ const useGetMemberPostsQuery = ({ page, size = 10 }: PageAndSize) => {
 };
 
 const useGetMemberTempPostsQuery = ({ page, size = 10 }: PageAndSize) => {
-  const fetcher = () => axios.get('/posts/members/temp', { params: { page, size } }).then(({ data }) => data);
+  const fetcher = () => axios.get('/posts/temp', { params: { page, size } }).then(({ data }) => data);
 
   return useQuery<MemberPost>(postKeys.memberTempPost({ page, size }), fetcher, {
     keepPreviousData: true,

--- a/src/pages/Profile/Tab/BoardTab.tsx
+++ b/src/pages/Profile/Tab/BoardTab.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import TempBoardTable from './BoardTable/TempBoardTable';
 
 const BoardTab = () => {
-  return <>BoardTab</>;
+  return (
+    <div className="gird-cols-2 grid h-full w-full">
+      <TempBoardTable />
+    </div>
+  );
 };
 
 export default BoardTab;

--- a/src/pages/Profile/Tab/BoardTab.tsx
+++ b/src/pages/Profile/Tab/BoardTab.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import MyBoardTable from './BoardTable/MyBoardTable';
 import TempBoardTable from './BoardTable/TempBoardTable';
 
 const BoardTab = () => {
   return (
     <div className="gird-cols-2 grid h-full w-full">
       <TempBoardTable />
+      <MyBoardTable />
     </div>
   );
 };

--- a/src/pages/Profile/Tab/BoardTable/MyBoardTable.tsx
+++ b/src/pages/Profile/Tab/BoardTable/MyBoardTable.tsx
@@ -2,28 +2,33 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Typography } from '@mui/material';
 import { DateTime } from 'luxon';
-import { useGetMemberTempPostsQuery } from '@api/postApi';
+import { useRecoilValue } from 'recoil';
+import { useGetMemberPostsQuery } from '@api/postApi';
 import usePagination from '@hooks/usePagination';
+import memberState from '@recoil/member.recoil';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 
-interface TempBoardRow {
+interface MyBoardRow {
   id: number;
   num: number;
   title: string;
   categoryId: number;
   categoryName: string;
+  visitCount: number;
+  isSecret: boolean;
   registerTime: string;
 }
 
-const tempBoardColumns: Column<TempBoardRow>[] = [
+const myBoardColumns: Column<MyBoardRow>[] = [
   { key: 'num', headerName: '번호' },
   { key: 'categoryName', headerName: '카테고리' },
   { key: 'title', headerName: '제목' },
   { key: 'registerTime', headerName: '작성일' },
+  { key: 'visitCount', headerName: '조회수' },
 ];
 
-const TempBoardChildComponent = ({ key, value }: ChildComponent<TempBoardRow>) => {
+const MyBoardChildComponent = ({ key, value }: ChildComponent<MyBoardRow>) => {
   switch (key) {
     case 'registerTime':
       return DateTime.fromSQL(value as string).toFormat('yy.MM.dd');
@@ -32,29 +37,30 @@ const TempBoardChildComponent = ({ key, value }: ChildComponent<TempBoardRow>) =
   }
 };
 
-const TempBoardTable = () => {
+const MyBoardTable = () => {
+  const userInfo = useRecoilValue(memberState);
   const navigate = useNavigate();
   const { page, getRowNumber } = usePagination();
 
-  const { data: tempBoard } = useGetMemberTempPostsQuery({ page });
+  const { data: myBoard } = useGetMemberPostsQuery({ page, memberId: userInfo?.memberId as number });
 
-  if (!tempBoard) return null;
+  if (!myBoard) return null;
 
   return (
     <div className="h-full w-full">
-      <Typography>임시 작성글</Typography>
-      <StandardTable<TempBoardRow>
-        columns={tempBoardColumns}
-        rows={tempBoard.content.map((item, index) => ({
-          num: getRowNumber({ size: tempBoard.size, index }),
+      <Typography>작성글</Typography>
+      <StandardTable<MyBoardRow>
+        columns={myBoardColumns}
+        rows={myBoard.content.map((item, index) => ({
+          num: getRowNumber({ size: myBoard.size, index }),
           ...item,
         }))}
-        childComponent={TempBoardChildComponent}
+        childComponent={MyBoardChildComponent}
         onRowClick={({ rowData }) => navigate(`/board/view/${rowData.id}`)}
-        paginationOption={{ rowsPerPage: tempBoard.size, totalItems: tempBoard.totalElements }}
+        paginationOption={{ rowsPerPage: myBoard.size, totalItems: myBoard.totalElements }}
       />
     </div>
   );
 };
 
-export default TempBoardTable;
+export default MyBoardTable;

--- a/src/pages/Profile/Tab/BoardTable/TempBoardTable.tsx
+++ b/src/pages/Profile/Tab/BoardTable/TempBoardTable.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+import { useGetMemberTempPostsQuery } from '@api/postApi';
+import usePagination from '@hooks/usePagination';
+import StandardTable from '@components/Table/StandardTable';
+import { Column } from '@components/Table/StandardTable.interface';
+
+interface TempBoardRow {
+  id: number;
+  num: number;
+  title: string;
+  categoryId: number;
+  categoryName: string;
+  registerTime: string;
+}
+
+const tempBoardColumns: Column<TempBoardRow>[] = [
+  { key: 'num', headerName: '번호' },
+  { key: 'categoryName', headerName: '카테고리' },
+  { key: 'title', headerName: '제목' },
+  { key: 'registerTime', headerName: '작성일' },
+];
+
+const TempBoardChildComponent = () => {
+  return <div />;
+};
+
+const TempBoardTable = () => {
+  const { page, getRowNumber } = usePagination();
+
+  const { data: tempBoard } = useGetMemberTempPostsQuery({ page });
+
+  if (!tempBoard) return null;
+
+  return (
+    <div className="h-full w-full">
+      <Typography>임시 작성글</Typography>
+      <StandardTable<TempBoardRow>
+        columns={tempBoardColumns}
+        rows={tempBoard.content.map((item, index) => ({
+          num: getRowNumber({ size: tempBoard.size, index }),
+          ...item,
+        }))}
+        childComponent={TempBoardChildComponent}
+        paginationOption={{ rowsPerPage: tempBoard.size, totalItems: tempBoard.totalElements }}
+      />
+    </div>
+  );
+};
+
+export default TempBoardTable;


### PR DESCRIPTION
## 연관 이슈
#642 

## 작업 요약
임시 작성글과 작성글 탭입니다

## 작업 상세 설명
각각 컴포넌트로 넣어줬습니다.
usePagenation이 겹쳐 페이지가 같이 넘어가는 문제가 있습니다. 옆에 포인트내역도 같이 넘어갑니다...
클릭시 board/view/{boardId}로 넘어가도록 했습니다
개발자모드를 켠 상태에서 보드로 갔다가 뒤로가기를 하면 에러창이 뜹니다. 개발자모드를 안키면 안뜨고 그냥 무시해도 동작에 문제가 없긴합니다...

## 리뷰 요구사항
5분
페이지 이동경로 맞는지 확인부탁드립니다.

## Preview 이미지
<img width="1126" alt="스크린샷 2023-09-12 오후 5 10 19" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/51306225/da7b5880-5d19-486e-9345-b794f67958c6">

