### PR TITLE
Feature/회원가입 남은 작업 처리 - 중복 체크 관련

### DIFF
--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -2,10 +2,10 @@ import { useMutation, useQuery } from 'react-query';
 import axios from 'axios';
 import { SignUpDuplication, SignUpInfo } from './dto';
 
-const signUpKeys = {
+export const signUpKeys = {
   idDuplication: ['sighUp', 'duplication', 'loginId'] as const,
   emailDuplication: (email: string) => ['sighUp', 'duplication', 'email', email] as const,
-  studentIdDuplication: ['sighUp', 'duplication', 'studentId'] as const,
+  studentIdDuplication: (studentId: string) => ['sighUp', 'duplication', 'studentId', studentId] as const,
 };
 
 const useSignUpMutation = () => {
@@ -32,10 +32,10 @@ const useCheckEmailDuplicationQuery = ({ email, enabled }: { email: string; enab
   return useQuery<SignUpDuplication>(signUpKeys.emailDuplication(email), fetcher, { enabled });
 };
 
-const useCheckStudentIdDuplicationQuery = ({ studentId }: { studentId: string }) => {
+const useCheckStudentIdDuplicationQuery = ({ studentId, enabled }: { studentId: string; enabled: boolean }) => {
   const fetcher = () => axios.get('/sign-up/exists/student-id', { params: { studentId } }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.studentIdDuplication, fetcher);
+  return useQuery<SignUpDuplication>(signUpKeys.studentIdDuplication(studentId), fetcher, { enabled });
 };
 
 export {

--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { SignUpDuplication, SignUpInfo } from './dto';
 
 export const signUpKeys = {
-  idDuplication: ['sighUp', 'duplication', 'loginId'] as const,
+  idDuplication: (loginId: string) => ['sighUp', 'duplication', 'loginId', loginId] as const,
   emailDuplication: (email: string) => ['sighUp', 'duplication', 'email', email] as const,
   studentIdDuplication: (studentId: string) => ['sighUp', 'duplication', 'studentId', studentId] as const,
 };
@@ -20,10 +20,10 @@ const useEmailAuthMutation = () => {
   return useMutation(fetcher);
 };
 
-const useCheckLoginIdDuplicationQuery = ({ loginId }: { loginId: string }) => {
+const useCheckLoginIdDuplicationQuery = ({ loginId, enabled }: { loginId: string; enabled: boolean }) => {
   const fetcher = () => axios.get('/sign-up/exists/login-id', { params: { loginId } }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.idDuplication, fetcher);
+  return useQuery<SignUpDuplication>(signUpKeys.idDuplication(loginId), fetcher, { enabled });
 };
 
 const useCheckEmailDuplicationQuery = ({ email, enabled }: { email: string; enabled: boolean }) => {

--- a/src/components/Input/EmailAuthInput.tsx
+++ b/src/components/Input/EmailAuthInput.tsx
@@ -29,7 +29,6 @@ const EmailAuthInput = forwardRef(
         ref={ref}
         hasBackground
         className={className}
-        required
         disabled={inputDisabled}
         name="email"
         value={value}

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -91,7 +91,7 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
               helperText={error?.message}
               endAdornment={
                 isLoginIdDuplicate?.duplicate === false && !error ? (
-                  <VscCheck className="fill-pointBlue" />
+                  <VscCheck size={20} className="fill-pointBlue" />
                 ) : (
                   <FilledButton small onClick={handleCheckLoginIdDuplicateClick} disabled={Boolean(error) || !isDirty}>
                     중복 확인

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -1,8 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import { useQueryClient } from 'react-query';
 import { Stack } from '@mui/material';
+import { VscCheck } from 'react-icons/vsc';
 import { useSetRecoilState } from 'recoil';
 
+import { signUpKeys, useCheckLoginIdDuplicationQuery } from '@api/signUpApi';
+import FilledButton from '@components/Button/FilledButton';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import StandardInput from '@components/Input/StandardInput';
 import signUpPageState from '../SignUp.recoil';
@@ -12,6 +16,8 @@ interface SignUpFirstInputSectionProps {
 }
 
 const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProps) => {
+  const [loginIdState, setLoginIdState] = useState('');
+  const [checkLoginIdDuplicateEnabled, setCheckLoginIdDuplicateEnabled] = useState(false);
   const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
   const setSignUpPageState = useSetRecoilState(signUpPageState);
 
@@ -19,13 +25,44 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
     control,
     getValues,
     handleSubmit,
+    watch,
+    setError,
     formState: { isSubmitting, isValid },
   } = useForm({ mode: 'onBlur' });
+
+  const queryClient = useQueryClient();
+  const { data: isLoginIdDuplicate } = useCheckLoginIdDuplicationQuery({
+    loginId: loginIdState,
+    enabled: checkLoginIdDuplicateEnabled,
+  });
 
   const handleFirstStepFormSubmit: SubmitHandler<FieldValues> = ({ loginId, password }) => {
     setSignUpPageState((prev) => ({ ...prev, loginId, password }));
     setCurrentStep(2);
   };
+
+  const handleCheckLoginIdDuplicateClick = () => {
+    setCheckLoginIdDuplicateEnabled(true);
+    setLoginIdState(getValues('loginId'));
+  };
+
+  useEffect(() => {
+    if (!isLoginIdDuplicate) return;
+
+    if (isLoginIdDuplicate.duplicate === true) {
+      setError('loginId', { message: '이미 존재하는 아이디입니다.' });
+      setCheckLoginIdDuplicateEnabled(false);
+    }
+  }, [isLoginIdDuplicate]);
+
+  useEffect(() => {
+    if (!isLoginIdDuplicate) return;
+
+    if (isLoginIdDuplicate.duplicate === false) {
+      setCheckLoginIdDuplicateEnabled(false);
+      queryClient.setQueryData(signUpKeys.idDuplication(loginIdState), undefined);
+    }
+  }, [watch('loginId')]);
 
   return (
     <Stack component="form" spacing={2} onSubmit={handleSubmit(handleFirstStepFormSubmit)}>
@@ -44,9 +81,24 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
             message: '4~12자 영어, 숫자, _ 만 가능합니다.',
           },
         }}
-        render={({ field, fieldState: { error } }) => {
+        render={({ field, fieldState: { error, isDirty } }) => {
           return (
-            <StandardInput hasBackground label="아이디" {...field} error={Boolean(error)} helperText={error?.message} />
+            <StandardInput
+              hasBackground
+              label="아이디"
+              {...field}
+              error={Boolean(error)}
+              helperText={error?.message}
+              endAdornment={
+                isLoginIdDuplicate?.duplicate === false && !error ? (
+                  <VscCheck className="fill-pointBlue" />
+                ) : (
+                  <FilledButton small onClick={handleCheckLoginIdDuplicateClick} disabled={Boolean(error) || !isDirty}>
+                    중복 확인
+                  </FilledButton>
+                )
+              }
+            />
           );
         }}
       />
@@ -107,7 +159,10 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
       />
 
       <div className="absolute bottom-0 right-0">
-        <OutlinedButton type="submit" disabled={!isValid || isSubmitting}>
+        <OutlinedButton
+          type="submit"
+          disabled={!isValid || isSubmitting || !isLoginIdDuplicate || isLoginIdDuplicate.duplicate === true}
+        >
           다음
         </OutlinedButton>
       </div>

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -110,7 +110,7 @@ const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionPro
               helperText={error?.message}
               endAdornment={
                 isStudentIdDuplicate?.duplicate === false && !error ? (
-                  <VscCheck className="fill-pointBlue" />
+                  <VscCheck size={20} className="fill-pointBlue" />
                 ) : (
                   <FilledButton
                     small

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -33,12 +33,10 @@ const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionPro
   } = useForm({ mode: 'onBlur' });
 
   const queryClient = useQueryClient();
-  const { data: isStudentIdDuplicate, isSuccess: checkStudentIdDuplicationSuccess } = useCheckStudentIdDuplicationQuery(
-    {
-      studentId: studentIdState,
-      enabled: checkStudentIdDuplicateEnabled,
-    },
-  );
+  const { data: isStudentIdDuplicate } = useCheckStudentIdDuplicationQuery({
+    studentId: studentIdState,
+    enabled: checkStudentIdDuplicateEnabled,
+  });
 
   const handleSecondStepFormSubmit: SubmitHandler<FieldValues> = ({ realName, studentId, birthday }) => {
     setSignUpPageState((prev) => ({ ...prev, realName, studentId, birthday: birthday.toFormat('yyyy.MM.dd') }));
@@ -57,7 +55,7 @@ const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionPro
       setError('studentId', { message: '이미 존재하는 학번입니다.' });
       setCheckStudentIdDuplicateEnabled(false);
     }
-  }, [checkStudentIdDuplicationSuccess]);
+  }, [isStudentIdDuplicate]);
 
   useEffect(() => {
     if (!isStudentIdDuplicate) return;

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -147,7 +147,10 @@ const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionPro
         }}
       />
       <div className="absolute bottom-0 right-0">
-        <OutlinedButton type="submit" disabled={!isValid || isSubmitting}>
+        <OutlinedButton
+          type="submit"
+          disabled={!isValid || isSubmitting || !isStudentIdDuplicate || isStudentIdDuplicate.duplicate === true}
+        >
           다음
         </OutlinedButton>
       </div>

--- a/src/pages/SignUp/Section/SignUpThirdInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpThirdInputSection.tsx
@@ -86,7 +86,8 @@ const SignUpThirdInputSection = () => {
               {...field}
               error={Boolean(error)}
               helperText={error?.message}
-              buttonDisabled={Boolean(error) || !isDirty}
+              inputDisabled={isEmailSent && checkEmailDuplicationSuccess}
+              buttonDisabled={Boolean(error) || !isDirty || isEmailSent}
               onAuthButtonClick={handleRequestVerificationCode}
             />
           );


### PR DESCRIPTION
## 연관 이슈
- Close #295 
- Close #296

## 작업 요약
- 학번 중복 체크, 아이디 중복 체크 적용하였습니다.

## 작업 상세 설명
- 중복 확인 버튼 클릭 시
  - 중복된 학번/아이디면 인풋에 에러 문구 띄워주고
  - 중복되지 않은 경우 체크 아이콘으로 변경되도록 처리
- 체크 아이콘으로 변경 후 학번/아이디 변경 시 다시 중복 확인 전 상태로 리셋

등 처리해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 15분
- 에러 발생 후 인풋 변경 시 바로 에러 제거되는 게 아닌 `onBlur` 시 제거 됩니다. 게시글 작성 쪽도 마찬가지인데 추후 한꺼번에 처리해보겠습니다!

## Preview 이미지

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/5d1a5d85-45e8-47a4-80df-6af6d0e7236d

