### PR TITLE
fest : 프로필 섹션 ui 구성 및 회원정보 연결

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -509,3 +509,24 @@ export interface CallenderChartInfo {
   day: string;
   value: number;
 }
+
+export interface FollowInfo {
+  id: number;
+  name: string;
+  generation: string;
+  thumbnailPath: string | null;
+}
+
+export interface ProfileInfo {
+  id: number;
+  realName: string;
+  generation: string;
+  birthday: string;
+  emailAddress: string;
+  thumbnailPath: string | null;
+  point: number;
+  memberType: string;
+  memberJobs: Role[];
+  follower: FollowInfo[];
+  followee: FollowInfo[];
+}

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation } from 'react-query';
+import axios from 'axios';
+import { ProfileInfo } from './dto';
+
+const profileKeys = {
+  profileInfo: ['profile', 'profileInfo'] as const,
+};
+
+const useGetProfileQuery = (memberId: number) => {
+  const fetcher = () => axios.get(`/members/${memberId}/profile`).then(({ data }) => data);
+
+  return useQuery<ProfileInfo>(profileKeys.profileInfo, fetcher, { enabled: memberId !== 0 });
+};
+
+const useFollowMutation = (memberId: number) => {
+  const fetcher = () => axios.post(`/members/${memberId}/follow`);
+
+  return useMutation(fetcher);
+};
+
+const useUnFollowMutation = (memberId: number) => {
+  const fetcher = () => axios.post(`/members/${memberId}/unfollow `);
+
+  return useMutation(fetcher);
+};
+
+export { useGetProfileQuery, useFollowMutation, useUnFollowMutation };

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -4,6 +4,7 @@ import AttendanceTab from './Tab/AttendanceTab';
 import BoardTab from './Tab/BoardTab';
 import BookTab from './Tab/BookTab';
 import PointTab from './Tab/PointTab';
+import ProfileTab from './Tab/ProfileTab';
 
 const Profile = () => {
   const tabList = [
@@ -16,7 +17,9 @@ const Profile = () => {
 
   return (
     <div className="mb-40 mt-header flex w-full flex-col justify-start xl:flex-row xl:justify-center">
-      <div className="flex w-full border border-subGray xl:h-full xl:w-80">프로필</div>
+      <div className="flex w-full border border-subGray xl:h-full xl:w-80">
+        <ProfileTab />
+      </div>
       <div className="flex w-full max-w-container flex-col xl:h-full">
         <StandardTab options={tabList} tab={tab} setTab={setTab} />
         <div className="mt-4 flex h-full border border-subGray p-4">

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import StandardTab from '@components/Tab/StandardTab';
+import ProfileSection from './Section/ProfileSection';
 import AttendanceTab from './Tab/AttendanceTab';
 import BoardTab from './Tab/BoardTab';
 import BookTab from './Tab/BookTab';
 import PointTab from './Tab/PointTab';
-import ProfileTab from './Tab/ProfileTab';
 
 const Profile = () => {
   const tabList = [
@@ -18,7 +18,7 @@ const Profile = () => {
   return (
     <div className="mb-40 mt-header flex w-full flex-col justify-start xl:flex-row xl:justify-center">
       <div className="flex w-full border border-subGray xl:h-full xl:w-80">
-        <ProfileTab />
+        <ProfileSection />
       </div>
       <div className="flex w-full max-w-container flex-col xl:h-full">
         <StandardTab options={tabList} tab={tab} setTab={setTab} />

--- a/src/pages/Profile/Section/ProfileSection.tsx
+++ b/src/pages/Profile/Section/ProfileSection.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import Typography from '@mui/material/Typography';
+import { Avatar, Typography } from '@mui/material';
 import { useRecoilValue } from 'recoil';
 import { useGetProfileQuery } from '@api/memberApi';
 import memberState from '@recoil/member.recoil';
 import OutlinedButton from '@components/Button/OutlinedButton';
-import ServerImg from '@components/Image/ServerImg';
 
 const ProfileSection = () => {
   const userInfo = useRecoilValue(memberState);
@@ -12,8 +11,12 @@ const ProfileSection = () => {
 
   return (
     <div className="flex w-full flex-col space-y-8 p-4">
-      <div className="m-4 flex h-64 w-64 bg-subBlack">
-        <ServerImg src={profileInfo?.thumbnailPath || ''} alt="profile thumbnail" />
+      <div className="m-4">
+        <Avatar
+          className="!h-64 !w-64 !bg-subBlack !text-white"
+          alt="profile thumbnail"
+          src={userInfo?.thumbnailPath || ''}
+        />
       </div>
       <div className="flex items-center justify-between">
         <Typography variant="h1" className="!font-semibold">

--- a/src/pages/Profile/Section/ProfileSection.tsx
+++ b/src/pages/Profile/Section/ProfileSection.tsx
@@ -6,7 +6,7 @@ import memberState from '@recoil/member.recoil';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import ServerImg from '@components/Image/ServerImg';
 
-const ProfileTab = () => {
+const ProfileSection = () => {
   const userInfo = useRecoilValue(memberState);
   const { data: profileInfo } = useGetProfileQuery(userInfo?.memberId || 0);
 
@@ -56,4 +56,4 @@ const ProfileTab = () => {
   );
 };
 
-export default ProfileTab;
+export default ProfileSection;

--- a/src/pages/Profile/Tab/ProfileTab.tsx
+++ b/src/pages/Profile/Tab/ProfileTab.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import { useRecoilValue } from 'recoil';
+import { useGetProfileQuery } from '@api/memberApi';
+import memberState from '@recoil/member.recoil';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import ServerImg from '@components/Image/ServerImg';
+
+const ProfileTab = () => {
+  const userInfo = useRecoilValue(memberState);
+  const { data: profileInfo } = useGetProfileQuery(userInfo?.memberId || 0);
+
+  return (
+    <div className="flex w-full flex-col space-y-8 p-4">
+      <div className="m-4 flex h-64 w-64 bg-subBlack">
+        <ServerImg src={profileInfo?.thumbnailPath || ''} alt="profile thumbnail" />
+      </div>
+      <div className="flex items-center justify-between">
+        <Typography variant="h1" className="!font-semibold">
+          {profileInfo?.realName}
+        </Typography>
+        <div>뱃지</div>
+      </div>
+
+      <div className="flex space-x-5">
+        <Typography className="text-pointBlue ">팔로워 0</Typography>
+        <Typography>팔로잉 0</Typography>
+      </div>
+
+      <div className="flex flex-col items-center space-y-2">
+        <div className="w-full border border-pointBlue" />
+        <Typography variant="h1">POINT</Typography>
+        <Typography variant="h3" className="!text-pointBlue">
+          {profileInfo?.point}
+        </Typography>
+        <div className="w-full border border-pointBlue" />
+      </div>
+
+      <div className="flex space-x-5">
+        <div className="flex flex-col space-y-4">
+          <Typography>기수</Typography>
+          <Typography>이메일</Typography>
+          <Typography>생년월일</Typography>
+        </div>
+        <div className="flex flex-col space-y-4">
+          <Typography>{profileInfo?.generation} 기</Typography>
+          <Typography>{profileInfo?.emailAddress}</Typography>
+          <Typography>{profileInfo?.birthday}</Typography>
+        </div>
+      </div>
+      <div className="flex flex-col space-y-4">
+        <OutlinedButton className="w-full">프로필 수정</OutlinedButton>
+        <OutlinedButton className="w-full">계정 정보 수정</OutlinedButton>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileTab;


### PR DESCRIPTION

## 연관 이슈
- #661

## 작업 요약
- 프로필 섹션 ui 구성 및 회원정보 연결

## 리뷰 요구사항
- ui 대충 틀만 구현해서, 14.0기 같은 세세한건 냅뒀습니다!
- 아 혹시 기본 프로필은 어디서 가져오면 될까요??

## Preview 이미지
<img width="1086" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/2c5b9ec5-159f-4385-9d17-ed80e5932ea7">
