### PR TITLE
Feature/page param key 받아서 처리 가능하도록 확장 #658

### DIFF
--- a/src/components/Pagination/StandardTablePagination.interface.ts
+++ b/src/components/Pagination/StandardTablePagination.interface.ts
@@ -1,4 +1,5 @@
 export interface PaginationOption {
   rowsPerPage?: number;
   totalItems?: number;
+  pageKey?: string;
 }

--- a/src/components/Pagination/StandardTablePagination.tsx
+++ b/src/components/Pagination/StandardTablePagination.tsx
@@ -5,10 +5,10 @@ import './pagination.css';
 import usePagination from '@hooks/usePagination';
 import { PaginationOption } from './StandardTablePagination.interface';
 
-const StandardTablePagination = ({ rowsPerPage = 10, totalItems = -1 }: PaginationOption) => {
+const StandardTablePagination = ({ pageKey, rowsPerPage = 10, totalItems = -1 }: PaginationOption) => {
   const totalPages = Math.ceil(totalItems / rowsPerPage);
 
-  const { page, setPage } = usePagination();
+  const { page, setPage } = usePagination(pageKey);
 
   const setoffPageDiff = (prevPage: number, reverse?: boolean) => {
     // TablePagination page의 인덱스와 Pagination page의 인덱스 간 차이(1) 상쇄를 위한 동작입니다.

--- a/src/components/Pagination/StandardTablePagination.tsx
+++ b/src/components/Pagination/StandardTablePagination.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React from 'react';
 import { Pagination, TablePagination } from '@mui/material';
 
 import './pagination.css';
+import usePagination from '@hooks/usePagination';
 import { PaginationOption } from './StandardTablePagination.interface';
 
 const StandardTablePagination = ({ rowsPerPage = 10, totalItems = -1 }: PaginationOption) => {
   const totalPages = Math.ceil(totalItems / rowsPerPage);
 
-  const [page, setPage] = useState(0);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const { page, setPage } = usePagination();
 
   const setoffPageDiff = (prevPage: number, reverse?: boolean) => {
     // TablePagination page의 인덱스와 Pagination page의 인덱스 간 차이(1) 상쇄를 위한 동작입니다.
@@ -17,18 +16,8 @@ const StandardTablePagination = ({ rowsPerPage = 10, totalItems = -1 }: Paginati
   };
 
   const handleChangePage = (event: React.ChangeEvent<unknown>, newPage: number) => {
-    setPage(setoffPageDiff(newPage, true));
-    setSearchParams({ ...Object.fromEntries(searchParams), page: String(newPage) });
+    setPage(newPage);
   };
-
-  useEffect(() => {
-    if (!searchParams.get('page')) {
-      setSearchParams({ ...Object.fromEntries(searchParams), page: String(setoffPageDiff(page)) });
-      return;
-    }
-
-    setPage(setoffPageDiff(Number(searchParams.get('page')), true));
-  }, [searchParams.get('page')]);
 
   return (
     <div className="flex !w-full items-center justify-between bg-middleBlack">

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -11,12 +11,12 @@ const usePagination = (pageKey = 'page') => {
   };
 
   const setPage = (newPage: number) => {
-    setSearchParams({ ...Object.fromEntries(searchParams), page: String(newPage) });
+    setSearchParams({ ...Object.fromEntries(searchParams), [pageKey]: String(newPage) });
   };
 
   useEffect(() => {
     if (!searchParams.get(pageKey)) {
-      setSearchParams({ ...Object.fromEntries(searchParams), page: String(1) });
+      setSearchParams({ ...Object.fromEntries(searchParams), [pageKey]: String(1) });
     }
   }, [page]);
 

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,15 +1,26 @@
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-const usePagination = () => {
-  const [searchParams] = useSearchParams();
+const usePagination = (pageKey = 'page') => {
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const page = searchParams.get('page') ? Number(searchParams.get('page')) - 1 : 0;
+  const page = searchParams.get(pageKey) ? Number(searchParams.get(pageKey)) - 1 : 0;
 
   const getRowNumber = ({ size = 10, index }: { size?: number; index: number }) => {
     return size * page + (index + 1);
   };
 
-  return { page, getRowNumber };
+  const setPage = (newPage: number) => {
+    setSearchParams({ ...Object.fromEntries(searchParams), page: String(newPage) });
+  };
+
+  useEffect(() => {
+    if (!searchParams.get(pageKey)) {
+      setSearchParams({ ...Object.fromEntries(searchParams), page: String(1) });
+    }
+  }, [page]);
+
+  return { page, getRowNumber, setPage };
 };
 
 export default usePagination;


### PR DESCRIPTION
## 연관 이슈
- Close #658, Close #647

## 작업 요약
- 한 페이지에 여러 테이블 사용 시에도 페이지네이션 원활하게 사용할 수 있도록 pageKey 받도록 확장해주었습니다.

## 작업 상세 설명
- 테이블 페이지네이션과 usePagination 훅 개별적으로 page searchParam 다루도록 처리해주었는데 서로 연계되는 로직이어서 테이블 페이지네이션 내부에서도 usePagination 훅을 사용한 로직으로 변경해주었습니다.
- pageKey 넘겨주지 않으면 기존과 똑같이 page라는 이름의 key로 적용됩니다.

## 리뷰 요구사항
- 10분
- 처리 방식 괜찮은 지 체크 부탁드립니다!

## Preview 예제 코드
<img width="500" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/8c21ae53-fb6a-46be-872b-2e31da4c5fe5">
<img width="500" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/2b7801ef-807d-4db3-8ca5-19e69dc0c39c">
