### PR TITLE
Feature/계정 정보 수정 모달 #679

### DIFF
--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -59,6 +59,13 @@ const useEditEmailMutation = () => {
   return useMutation(fetcher);
 };
 
+const useEditPasswordMutation = () => {
+  const fetcher = ({ newPassword }: { newPassword: string }) =>
+    axios.patch('/members/change-password', { newPassword }).then(({ data }) => data);
+
+  return useMutation(fetcher);
+};
+
 export {
   useGetProfileQuery,
   useFollowMutation,
@@ -67,4 +74,5 @@ export {
   useEditProfileThumbnailMutation,
   useNewEmailAuthMutation,
   useEditEmailMutation,
+  useEditPasswordMutation,
 };

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -52,6 +52,13 @@ const useNewEmailAuthMutation = () => {
   return useMutation(fetcher);
 };
 
+const useEditEmailMutation = () => {
+  const fetcher = ({ email, auth, password }: { email: string; auth: string; password: string }) =>
+    axios.patch('/members/email', { email, auth, password }).then(({ data }) => data);
+
+  return useMutation(fetcher);
+};
+
 export {
   useGetProfileQuery,
   useFollowMutation,
@@ -59,4 +66,5 @@ export {
   useEditProfileMutation,
   useEditProfileThumbnailMutation,
   useNewEmailAuthMutation,
+  useEditEmailMutation,
 };

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -46,10 +46,17 @@ const useEditProfileThumbnailMutation = () => {
   return useMutation(fetcher);
 };
 
+const useNewEmailAuthMutation = () => {
+  const fetcher = (email: string) => axios.post('/members/email-auth', { email }).then(({ data }) => data);
+
+  return useMutation(fetcher);
+};
+
 export {
   useGetProfileQuery,
   useFollowMutation,
   useUnFollowMutation,
   useEditProfileMutation,
   useEditProfileThumbnailMutation,
+  useNewEmailAuthMutation,
 };

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -22,7 +22,7 @@ const ConfirmModal = ({ open, onClose, modalWidth, title, children }: ConfirmMod
         <VscChromeClose className="fill-pointBlue" size={28} />
       </IconButton>
       <DialogTitle className="!font-bold text-pointBlue">{title}</DialogTitle>
-      <DialogContent className="min-h-[80px] min-w-[350px]">{children}</DialogContent>
+      <DialogContent className="sm:min-h-[80px] sm:min-w-[350px]">{children}</DialogContent>
     </Dialog>
   );
 };

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -72,7 +72,6 @@ const EditEmailSection = () => {
       width={{ sm: '100%' }}
       spacing={{ xs: 2, md: 4 }}
       marginBottom={4}
-      justifyContent="space-between"
       component="form"
       onSubmit={handleSubmit(handleEmailFormSubmit)}
     >
@@ -159,6 +158,113 @@ const EditEmailSection = () => {
   );
 };
 
+const EditPasswordSection = () => {
+  const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
+
+  const {
+    control,
+    getValues,
+    handleSubmit,
+    formState: { isSubmitting, isValid },
+  } = useForm({ mode: 'onBlur' });
+
+  const handlePasswordFormSubmit: SubmitHandler<FieldValues> = () => {
+    //
+  };
+
+  return (
+    <Stack
+      width={{ sm: '100%' }}
+      spacing={{ xs: 2, md: 4 }}
+      marginBottom={4}
+      component="form"
+      onSubmit={handleSubmit(handlePasswordFormSubmit)}
+    >
+      <Stack spacing={1}>
+        <Typography fontWeight="semibold">비밀번호 변경</Typography>
+        <Controller
+          name="password"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: '필수 정보입니다.',
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return (
+              <StandardInput
+                hasBackground
+                type="password"
+                label="현재 비밀번호"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message}
+              />
+            );
+          }}
+        />
+        <Controller
+          name="newPassword"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: '필수 정보입니다.',
+            minLength: {
+              value: 8,
+              message: '8글자 이상 입력해주세요.',
+            },
+            pattern: {
+              value: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+              message: '8~20자 영문과 숫자를 사용하세요.',
+            },
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return (
+              <StandardInput
+                hasBackground
+                type="password"
+                label="새 비밀번호"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message}
+              />
+            );
+          }}
+        />
+        <Controller
+          name="newPasswordConfirm"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: '필수 정보입니다.',
+            validate: {
+              confirmMatchPassward: (value) => {
+                if (getValues('newPassword') !== value) return '비밀번호가 일치하지 않습니다.';
+                setPasswordConfirmSuccessMsg('비밀번호가 일치합니다.');
+                return undefined;
+              },
+            },
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return (
+              <StandardInput
+                hasBackground
+                type="password"
+                label="새 비밀번호 확인"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message || passwordConfirmSuccessMsg}
+              />
+            );
+          }}
+        />
+      </Stack>
+      <OutlinedButton type="submit" disabled={!isValid || isSubmitting}>
+        다음
+      </OutlinedButton>
+    </Stack>
+  );
+};
+
 interface EditAccountModalProps {
   open: boolean;
   onClose: () => void;
@@ -175,6 +281,7 @@ const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
         justifyContent="space-between"
       >
         <EditEmailSection />
+        <EditPasswordSection />
       </Stack>
     </ConfirmModal>
   );

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -8,6 +8,7 @@ import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { emailRegex } from '@utils/validateEmail';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import EmailAuthInput from '@components/Input/EmailAuthInput';
+import StandardInput from '@components/Input/StandardInput';
 import TimerInput from '@components/Input/TimerInput';
 import ConfirmModal from '@components/Modal/ConfirmModal';
 
@@ -56,6 +57,26 @@ const EditEmailSection = () => {
       <Stack spacing={1} component="form" onSubmit={handleSubmit(handleEmailFormSubmit)}>
         <Typography fontWeight="semibold">이메일 변경</Typography>
         <Controller
+          name="password"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: '필수 정보입니다.',
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return (
+              <StandardInput
+                hasBackground
+                type="password"
+                label="현재 비밀번호"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message}
+              />
+            );
+          }}
+        />
+        <Controller
           name="email"
           defaultValue=""
           control={control}
@@ -69,7 +90,7 @@ const EditEmailSection = () => {
           render={({ field, fieldState: { error, isDirty } }) => {
             return (
               <EmailAuthInput
-                label="이메일"
+                label="새 이메일"
                 {...field}
                 error={Boolean(error)}
                 helperText={error?.message}

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -152,7 +152,7 @@ const EditEmailSection = () => {
         type="submit"
         disabled={!isValid || isSubmitting || Boolean(expirationTime && expirationTime < DateTime.now())}
       >
-        완료
+        이메일 변경
       </OutlinedButton>
     </Stack>
   );
@@ -261,7 +261,7 @@ const EditPasswordSection = () => {
         />
       </Stack>
       <OutlinedButton type="submit" disabled={!isValid || isSubmitting}>
-        다음
+        비밀번호 변경
       </OutlinedButton>
     </Stack>
   );

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
 import { Divider, Stack, Typography } from '@mui/material';
 
 import { DateTime } from 'luxon';
-import { useNewEmailAuthMutation } from '@api/memberApi';
+import { useEditEmailMutation, useNewEmailAuthMutation } from '@api/memberApi';
 import { useCheckEmailDuplicationQuery } from '@api/signUpApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { emailRegex } from '@utils/validateEmail';
@@ -22,6 +23,7 @@ const EditEmailSection = () => {
     handleSubmit,
     getValues,
     setError,
+    reset,
     formState: { isSubmitting, isValid },
   } = useForm({ mode: 'onBlur' });
 
@@ -30,13 +32,22 @@ const EditEmailSection = () => {
     enabled: isEmailSent,
   });
   const { mutate: newEmailAuth } = useNewEmailAuthMutation();
+  const { mutate: editEmail } = useEditEmailMutation();
 
   const handleRequestVerificationCode = () => {
     setIsEmailSent(true);
   };
 
-  const handleEmailFormSubmit: SubmitHandler<FieldValues> = () => {
-    // TODO
+  const handleEmailFormSubmit: SubmitHandler<FieldValues> = ({ email, auth, password }) => {
+    editEmail(
+      { email, auth, password },
+      {
+        onSuccess: () => {
+          toast.success('이메일 변경 성공하였습니다.');
+          reset();
+        },
+      },
+    );
   };
 
   useEffect(() => {
@@ -62,9 +73,10 @@ const EditEmailSection = () => {
       spacing={{ xs: 2, md: 4 }}
       marginBottom={4}
       justifyContent="space-between"
+      component="form"
       onSubmit={handleSubmit(handleEmailFormSubmit)}
     >
-      <Stack spacing={1} component="form" onSubmit={handleSubmit(handleEmailFormSubmit)}>
+      <Stack spacing={1}>
         <Typography fontWeight="semibold">이메일 변경</Typography>
         <Controller
           name="password"
@@ -112,7 +124,7 @@ const EditEmailSection = () => {
           }}
         />
         <Controller
-          name="authCode"
+          name="auth"
           defaultValue=""
           control={control}
           rules={{

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -11,18 +11,13 @@ import EmailAuthInput from '@components/Input/EmailAuthInput';
 import TimerInput from '@components/Input/TimerInput';
 import ConfirmModal from '@components/Modal/ConfirmModal';
 
-interface EditAccountModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
+const EditEmailSection = () => {
   const [expirationTime] = useState<DateTime | null>(null);
   const [isEmailSent, setIsEmailSent] = useState(false);
 
   const {
-    control: emailControl,
-    handleSubmit: handleEmailSubmit,
+    control,
+    handleSubmit,
     getValues,
     setError,
     formState: { isSubmitting, isValid },
@@ -37,7 +32,7 @@ const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
     setIsEmailSent(true);
   };
 
-  const handleSecondStepFormSubmit: SubmitHandler<FieldValues> = () => {
+  const handleEmailFormSubmit: SubmitHandler<FieldValues> = () => {
     // TODO
   };
 
@@ -51,6 +46,83 @@ const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
   }, [checkEmailDuplicationSuccess]);
 
   return (
+    <Stack
+      width={{ sm: '100%' }}
+      spacing={{ xs: 2, md: 4 }}
+      marginBottom={4}
+      justifyContent="space-between"
+      onSubmit={handleSubmit(handleEmailFormSubmit)}
+    >
+      <Stack spacing={1} component="form" onSubmit={handleSubmit(handleEmailFormSubmit)}>
+        <Typography fontWeight="semibold">이메일 변경</Typography>
+        <Controller
+          name="email"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: REQUIRE_ERROR_MSG,
+            pattern: {
+              value: emailRegex,
+              message: '이메일 주소를 다시 확인해주세요.',
+            },
+          }}
+          render={({ field, fieldState: { error, isDirty } }) => {
+            return (
+              <EmailAuthInput
+                label="이메일"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message}
+                inputDisabled={isEmailSent && checkEmailDuplicationSuccess}
+                buttonDisabled={Boolean(error) || !isDirty || isEmailSent}
+                onAuthButtonClick={handleRequestVerificationCode}
+              />
+            );
+          }}
+        />
+        <Controller
+          name="authCode"
+          defaultValue=""
+          control={control}
+          rules={{
+            required: REQUIRE_ERROR_MSG,
+          }}
+          render={({ field, fieldState: { error } }) => {
+            return (
+              <TimerInput
+                label="인증코드 입력"
+                {...field}
+                error={Boolean(error)}
+                helperText={error?.message}
+                disabled={
+                  !isEmailDuplicate ||
+                  isEmailDuplicate.duplicate ||
+                  !isEmailSent ||
+                  Boolean(expirationTime && expirationTime < DateTime.now())
+                }
+                expirationTime={expirationTime}
+              />
+            );
+          }}
+        />
+      </Stack>
+      <OutlinedButton
+        type="submit"
+        disabled={!isValid || isSubmitting || Boolean(expirationTime && expirationTime < DateTime.now())}
+      >
+        완료
+      </OutlinedButton>
+    </Stack>
+  );
+};
+
+interface EditAccountModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
+  return (
     <ConfirmModal open={open} onClose={onClose} title="계정 정보 수정" modalWidth="md">
       <Stack
         divider={<Divider orientation="vertical" flexItem />}
@@ -59,77 +131,10 @@ const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
         direction={{ sm: 'column', md: 'row' }}
         justifyContent="space-between"
       >
-        <Stack
-          width={{ sm: '100%' }}
-          spacing={{ xs: 2, md: 4 }}
-          marginBottom={4}
-          justifyContent="space-between"
-          onSubmit={handleEmailSubmit(handleSecondStepFormSubmit)}
-        >
-          <Stack spacing={1} component="form" onSubmit={handleEmailSubmit(handleSecondStepFormSubmit)}>
-            <Typography fontWeight="semibold">이메일 변경</Typography>
-            <Controller
-              name="email"
-              defaultValue=""
-              control={emailControl}
-              rules={{
-                required: REQUIRE_ERROR_MSG,
-                pattern: {
-                  value: emailRegex,
-                  message: '이메일 주소를 다시 확인해주세요.',
-                },
-              }}
-              render={({ field, fieldState: { error, isDirty } }) => {
-                return (
-                  <EmailAuthInput
-                    label="이메일"
-                    {...field}
-                    error={Boolean(error)}
-                    helperText={error?.message}
-                    inputDisabled={isEmailSent && checkEmailDuplicationSuccess}
-                    buttonDisabled={Boolean(error) || !isDirty || isEmailSent}
-                    onAuthButtonClick={handleRequestVerificationCode}
-                  />
-                );
-              }}
-            />
-            <Controller
-              name="authCode"
-              defaultValue=""
-              control={emailControl}
-              rules={{
-                required: REQUIRE_ERROR_MSG,
-              }}
-              render={({ field, fieldState: { error } }) => {
-                return (
-                  <TimerInput
-                    label="인증코드 입력"
-                    {...field}
-                    error={Boolean(error)}
-                    helperText={error?.message}
-                    disabled={
-                      !isEmailDuplicate ||
-                      isEmailDuplicate.duplicate ||
-                      !isEmailSent ||
-                      Boolean(expirationTime && expirationTime < DateTime.now())
-                    }
-                    expirationTime={expirationTime}
-                  />
-                );
-              }}
-            />
-          </Stack>
-          <OutlinedButton
-            type="submit"
-            disabled={!isValid || isSubmitting || Boolean(expirationTime && expirationTime < DateTime.now())}
-          >
-            완료
-          </OutlinedButton>
-        </Stack>
+        <EditEmailSection />
       </Stack>
     </ConfirmModal>
   );
 };
 
 export default EditAccountModal;
-

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -3,6 +3,7 @@ import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form
 import { Divider, Stack, Typography } from '@mui/material';
 
 import { DateTime } from 'luxon';
+import { useNewEmailAuthMutation } from '@api/memberApi';
 import { useCheckEmailDuplicationQuery } from '@api/signUpApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { emailRegex } from '@utils/validateEmail';
@@ -13,7 +14,7 @@ import TimerInput from '@components/Input/TimerInput';
 import ConfirmModal from '@components/Modal/ConfirmModal';
 
 const EditEmailSection = () => {
-  const [expirationTime] = useState<DateTime | null>(null);
+  const [expirationTime, setExpirationTime] = useState<DateTime | null>(null);
   const [isEmailSent, setIsEmailSent] = useState(false);
 
   const {
@@ -28,6 +29,7 @@ const EditEmailSection = () => {
     email: getValues('email'),
     enabled: isEmailSent,
   });
+  const { mutate: newEmailAuth } = useNewEmailAuthMutation();
 
   const handleRequestVerificationCode = () => {
     setIsEmailSent(true);
@@ -43,7 +45,15 @@ const EditEmailSection = () => {
     if (isEmailDuplicate.duplicate === true) {
       setError('email', { message: '이미 존재하는 이메일입니다.' });
       setIsEmailSent(false);
+      return;
     }
+
+    newEmailAuth(getValues('email'), {
+      onSuccess: () => {
+        setExpirationTime(DateTime.now().plus({ seconds: 300 }));
+        // TODO 유효시간 받아오기 setExpirationTime(DateTime.now().plus({ seconds: expiredSeconds }));
+      },
+    });
   }, [checkEmailDuplicationSuccess]);
 
   return (

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import { Divider, Stack, Typography } from '@mui/material';
 
 import { DateTime } from 'luxon';
-import { useEditEmailMutation, useNewEmailAuthMutation } from '@api/memberApi';
+import { useEditEmailMutation, useEditPasswordMutation, useNewEmailAuthMutation } from '@api/memberApi';
 import { useCheckEmailDuplicationQuery } from '@api/signUpApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { emailRegex } from '@utils/validateEmail';
@@ -168,8 +168,10 @@ const EditPasswordSection = () => {
     formState: { isSubmitting, isValid },
   } = useForm({ mode: 'onBlur' });
 
-  const handlePasswordFormSubmit: SubmitHandler<FieldValues> = () => {
-    //
+  const { mutate: editPassword } = useEditPasswordMutation();
+
+  const handlePasswordFormSubmit: SubmitHandler<FieldValues> = ({ newPassword }) => {
+    editPassword({ newPassword });
   };
 
   return (

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import { Divider, Stack, Typography } from '@mui/material';
+
+import { DateTime } from 'luxon';
+import { useCheckEmailDuplicationQuery } from '@api/signUpApi';
+import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+import { emailRegex } from '@utils/validateEmail';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import EmailAuthInput from '@components/Input/EmailAuthInput';
+import TimerInput from '@components/Input/TimerInput';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+
+interface EditAccountModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
+  const [expirationTime] = useState<DateTime | null>(null);
+  const [isEmailSent, setIsEmailSent] = useState(false);
+
+  const {
+    control: emailControl,
+    handleSubmit: handleEmailSubmit,
+    getValues,
+    setError,
+    formState: { isSubmitting, isValid },
+  } = useForm({ mode: 'onBlur' });
+
+  const { data: isEmailDuplicate, isSuccess: checkEmailDuplicationSuccess } = useCheckEmailDuplicationQuery({
+    email: getValues('email'),
+    enabled: isEmailSent,
+  });
+
+  const handleRequestVerificationCode = () => {
+    setIsEmailSent(true);
+  };
+
+  const handleSecondStepFormSubmit: SubmitHandler<FieldValues> = () => {
+    // TODO
+  };
+
+  useEffect(() => {
+    if (!checkEmailDuplicationSuccess) return;
+
+    if (isEmailDuplicate.duplicate === true) {
+      setError('email', { message: '이미 존재하는 이메일입니다.' });
+      setIsEmailSent(false);
+    }
+  }, [checkEmailDuplicationSuccess]);
+
+  return (
+    <ConfirmModal open={open} onClose={onClose} title="계정 정보 수정" modalWidth="md">
+      <Stack
+        divider={<Divider orientation="vertical" flexItem />}
+        spacing={6}
+        paddingX={{ sm: 0, md: 2 }}
+        direction={{ sm: 'column', md: 'row' }}
+        justifyContent="space-between"
+      >
+        <Stack
+          width={{ sm: '100%' }}
+          spacing={{ xs: 2, md: 4 }}
+          marginBottom={4}
+          justifyContent="space-between"
+          onSubmit={handleEmailSubmit(handleSecondStepFormSubmit)}
+        >
+          <Stack spacing={1} component="form" onSubmit={handleEmailSubmit(handleSecondStepFormSubmit)}>
+            <Typography fontWeight="semibold">이메일 변경</Typography>
+            <Controller
+              name="email"
+              defaultValue=""
+              control={emailControl}
+              rules={{
+                required: REQUIRE_ERROR_MSG,
+                pattern: {
+                  value: emailRegex,
+                  message: '이메일 주소를 다시 확인해주세요.',
+                },
+              }}
+              render={({ field, fieldState: { error, isDirty } }) => {
+                return (
+                  <EmailAuthInput
+                    label="이메일"
+                    {...field}
+                    error={Boolean(error)}
+                    helperText={error?.message}
+                    inputDisabled={isEmailSent && checkEmailDuplicationSuccess}
+                    buttonDisabled={Boolean(error) || !isDirty || isEmailSent}
+                    onAuthButtonClick={handleRequestVerificationCode}
+                  />
+                );
+              }}
+            />
+            <Controller
+              name="authCode"
+              defaultValue=""
+              control={emailControl}
+              rules={{
+                required: REQUIRE_ERROR_MSG,
+              }}
+              render={({ field, fieldState: { error } }) => {
+                return (
+                  <TimerInput
+                    label="인증코드 입력"
+                    {...field}
+                    error={Boolean(error)}
+                    helperText={error?.message}
+                    disabled={
+                      !isEmailDuplicate ||
+                      isEmailDuplicate.duplicate ||
+                      !isEmailSent ||
+                      Boolean(expirationTime && expirationTime < DateTime.now())
+                    }
+                    expirationTime={expirationTime}
+                  />
+                );
+              }}
+            />
+          </Stack>
+          <OutlinedButton
+            type="submit"
+            disabled={!isValid || isSubmitting || Boolean(expirationTime && expirationTime < DateTime.now())}
+          >
+            완료
+          </OutlinedButton>
+        </Stack>
+      </Stack>
+    </ConfirmModal>
+  );
+};
+
+export default EditAccountModal;
+

--- a/src/pages/Profile/Section/ProfileSection.tsx
+++ b/src/pages/Profile/Section/ProfileSection.tsx
@@ -4,10 +4,12 @@ import { useRecoilValue } from 'recoil';
 import { useGetProfileQuery } from '@api/memberApi';
 import memberState from '@recoil/member.recoil';
 import OutlinedButton from '@components/Button/OutlinedButton';
+import EditAccountModal from '../Modal/EditAccountModal';
 import EditProfileModal from '../Modal/EditProfileModal';
 
 const ProfileSection = () => {
   const [editProfileModalOpen, setEditProfileModalOpen] = useState(false);
+  const [editAccountModalOpen, setEditAccountModalOpen] = useState(false);
 
   const userInfo = useRecoilValue(memberState);
   const { data: profileInfo } = useGetProfileQuery(userInfo?.memberId || 0);
@@ -58,7 +60,9 @@ const ProfileSection = () => {
         <OutlinedButton className="w-full" onClick={() => setEditProfileModalOpen(true)}>
           프로필 수정
         </OutlinedButton>
-        <OutlinedButton className="w-full">계정 정보 수정</OutlinedButton>
+        <OutlinedButton className="w-full" onClick={() => setEditAccountModalOpen(true)}>
+          계정 정보 수정
+        </OutlinedButton>
       </div>
       {profileInfo && (
         <EditProfileModal
@@ -67,6 +71,7 @@ const ProfileSection = () => {
           onClose={() => setEditProfileModalOpen(false)}
         />
       )}
+      <EditAccountModal open={editAccountModalOpen} onClose={() => setEditAccountModalOpen(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## 연관 이슈
- #679 

## 작업 요약
- 계정 정보 수정 모달 이메일 변경, 비밀번호 변경 기능 구현하였습니다.

## 작업 상세 설명
- 이메일 변경, 비밀번호 변경 한 컴포넌트로 처리하기엔 너무 크고, 파일 분리하기에는 구조 너무 세분화하는 것 같기도하고 어떻게 잡아야할 지 모르겠어서 한 파일 내에서 컴포넌트 쪼개주었습니다. 가장 아래에 있는 컴포넌트가 메인 컴포넌트 입니다!
- 이메일 인증과 비밀번호 관련 유효성 검사 등 로직은 회원가입 부분과 거의 동일합니다!

## 리뷰 요구사항
- 15분
- 현재 이메일 변경은 정상적으로 동작 안 돼서 백엔드에 문의 넣어둔 상태이고, 인증 메일 발송 시 유효시간 받아오도록 API 수정 요청 드려놓은 상태입니다.
- 탈퇴하기 해당 PR 머지되면 추후 작업 예정입니다.

## Preview 이미지
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/41312dfc-cf75-4aed-9da7-3b8fff4c3de1">
<img width="100" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/5d536805-765d-4eed-b296-284c6bb7f973">
