### PR TITLE
Feature/스터디 검색 필터 적용 #428

### DIFF
--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -4,6 +4,7 @@ import { InputLabel, Stack, Typography } from '@mui/material';
 import { SiNotion } from 'react-icons/si';
 import { VscGithubInverted, VscLink } from 'react-icons/vsc';
 
+import { PeriodicInfo } from '@api/dto';
 import { useAddStudyMutation } from '@api/studyApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import StandardInput from '@components/Input/StandardInput';
@@ -19,9 +20,10 @@ interface StudyModalProps {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   modalInfo: ModalInfo;
+  currentPeriod: PeriodicInfo;
 }
 
-const StudyModal = ({ open, setOpen, modalInfo }: StudyModalProps) => {
+const StudyModal = ({ open, setOpen, modalInfo, currentPeriod }: StudyModalProps) => {
   const [thumbnail, setThumbnail] = useState<Blob | null>(null);
   const memberIds: { id: number }[] = [];
 
@@ -40,8 +42,8 @@ const StudyModal = ({ open, setOpen, modalInfo }: StudyModalProps) => {
           notionLink: getValues('notionLink'),
           etcTitle: getValues('etcTitle'),
           etcLink: getValues('etcLink'),
-          year: 2023 /* TODO 년도 학기 정보 props로 받아오기 */,
-          season: 1,
+          year: currentPeriod.year,
+          season: currentPeriod.season,
           memberIds,
         },
         thumbnail,

--- a/src/pages/Study/Study.tsx
+++ b/src/pages/Study/Study.tsx
@@ -97,7 +97,12 @@ const Study = () => {
           )}
         </div>
       )}
-      <StudyModal open={studyModalOpen} setOpen={setStudyModalOpen} modalInfo={modalInfo} />
+      <StudyModal
+        open={studyModalOpen}
+        setOpen={setStudyModalOpen}
+        modalInfo={modalInfo}
+        currentPeriod={currentPeriod}
+      />
     </div>
   );
 };

--- a/src/pages/Study/Study.tsx
+++ b/src/pages/Study/Study.tsx
@@ -56,14 +56,14 @@ const Study = () => {
       <div className="mb-5 flex items-center justify-between">
         <div className="flex space-x-2">
           <Selector
-            className="w-24"
+            className="w-28"
             name="year"
             options={yearList}
             value={currentPeriod.year}
             onChange={handlePeriodChange}
           />
           <Selector
-            className="w-24"
+            className="w-28"
             name="season"
             options={seasonList}
             value={currentPeriod.season}

--- a/src/pages/Study/Study.tsx
+++ b/src/pages/Study/Study.tsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useReducer, useState } from 'react';
 
 import { SelectChangeEvent, Typography } from '@mui/material';
+import { DateTime } from 'luxon';
 import { useGetStudyListQuery } from '@api/studyApi';
-import { yearList } from '@mocks/StudyApi';
 import ActionButton from '@components/Button/ActionButton';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import Selector from '@components/Selector/Selector';
@@ -16,36 +16,39 @@ import { ModalInfo } from './Study.interface';
 
 const OLD_YEAR_BOUND = 2022;
 
+const yearList = [
+  { id: 0, content: `${OLD_YEAR_BOUND}년 이전` },
+  ...Array.from({ length: DateTime.now().year - OLD_YEAR_BOUND + 1 }, (v, i) => ({
+    id: OLD_YEAR_BOUND + i,
+    content: `${OLD_YEAR_BOUND + i}년`,
+  })),
+];
+
 const seasonList = [
-  { id: 0, content: '1학기' },
-  { id: 1, content: '여름방학' },
-  { id: 2, content: '2학기' },
-  { id: 3, content: '겨울방학' },
+  { id: 1, content: '1학기' },
+  { id: 2, content: '여름방학' },
+  { id: 3, content: '2학기' },
+  { id: 4, content: '겨울방학' },
 ];
 
 const Study = () => {
-  const [currentPeriod, setCurrentPeriod] = useState({ year: 0, season: 0 });
+  const [currentPeriod, setCurrentPeriod] = useState({ year: DateTime.now().year, season: DateTime.now().quarter });
 
   const [studyAccoridionOpen, toggleStudyAccoridionOpen] = useReducer((prev) => !prev, false);
   const [studyModalOpen, setStudyModalOpen] = useState(false);
   const [modalInfo, setModalInfo] = useState<ModalInfo>({ mode: 'Add' });
 
-  const { data: studyList } = useGetStudyListQuery({ year: 2023, season: 1 });
+  const { data: studyList } = useGetStudyListQuery({ year: currentPeriod.year, season: currentPeriod.season });
 
   const handlePeriodChange = (event: SelectChangeEvent<unknown>) => {
     const { name, value } = event.target;
-    setCurrentPeriod({ ...currentPeriod, [name]: Number(value as string) });
+    setCurrentPeriod({ ...currentPeriod, [name]: Number(value) });
   };
 
   const handleStudyCreateButtonClick = () => {
     setStudyModalOpen(true);
     setModalInfo({ mode: 'Add' });
   };
-
-  /* 처음 한 번만 동작하는 useEffect, 페이지 초기 값 셋팅 */
-  useEffect(() => {
-    setCurrentPeriod({ year: 0, season: 0 }); /* TODO 현재 연도, 분기 가져와서 초기화 */
-  }, []);
 
   return (
     <div>
@@ -67,13 +70,13 @@ const Study = () => {
             onChange={handlePeriodChange}
           />
         </div>
-        {Number(yearList[currentPeriod.year].content) >= OLD_YEAR_BOUND && (
+        {Number(currentPeriod.year) >= OLD_YEAR_BOUND && (
           <ActionButton mode="add" onClick={handleStudyCreateButtonClick}>
             추가
           </ActionButton>
         )}
       </div>
-      {Number(yearList[currentPeriod.year].content) < OLD_YEAR_BOUND ? (
+      {Number(currentPeriod.year) < OLD_YEAR_BOUND ? (
         <OldStudy list={[]} memberId={-1} toggleOpen={toggleStudyAccoridionOpen} setModalInfo={setModalInfo} />
       ) : (
         <div>

--- a/src/pages/Study/Study.tsx
+++ b/src/pages/Study/Study.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useReducer, useState } from 'react';
 
-import { SelectChangeEvent } from '@mui/material';
+import { SelectChangeEvent, Typography } from '@mui/material';
 import { useGetStudyListQuery } from '@api/studyApi';
 import { yearList } from '@mocks/StudyApi';
 import ActionButton from '@components/Button/ActionButton';
@@ -77,14 +77,21 @@ const Study = () => {
         <OldStudy list={[]} memberId={-1} toggleOpen={toggleStudyAccoridionOpen} setModalInfo={setModalInfo} />
       ) : (
         <div>
-          {studyList?.map((study) => (
-            <StudyAccordion
-              key={study.studyId}
-              study={study}
-              toggleOpen={toggleStudyAccoridionOpen}
-              setModalInfo={setModalInfo}
-            />
-          ))}
+          {studyList && studyList.length > 0 ? (
+            studyList.map((study) => (
+              <StudyAccordion
+                key={study.studyId}
+                study={study}
+                toggleOpen={toggleStudyAccoridionOpen}
+                setModalInfo={setModalInfo}
+              />
+            ))
+          ) : (
+            <Typography marginY={15} paddingY={8} textAlign="center" className="border-y border-pointBlue/70">
+              현재 등록된 스터디가 없습니다. <span className="text-pointBlue">+ 추가</span> 버튼을 클릭하여 스터디를
+              추가하세요.
+            </Typography>
+          )}
         </div>
       )}
       <StudyModal open={studyModalOpen} setOpen={setStudyModalOpen} modalInfo={modalInfo} />


### PR DESCRIPTION
## 연관 이슈
- #428

## 작업 요약
- 스터디 검색 필터 적용하였습니다.

## 작업 상세 설명
- 검색된 기간에 스터디 목록이 없을 경우 빈 화면 -> 안내 문구 추가해주었습니다.
- 셀렉터를 통해 선택한 기간의 스터디 목록을 불러오도록 처리해주었습니다. (default로는 현재 년도와 학기 불러 오도록 했습니다.)
- 년도 목록에 2022년 이전과 2022년 ~ 현재년도로 구성될 수 있도록 처리해주었습니다.
- 스터디 추가/수정 시에도 검색 기간에 대한 추가/수정으로 반영되도록 해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 7분

## Preview 이미지
![image](https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/be40e47f-97ac-4920-97e4-f68ca734a165)
<img width="1184" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/3adfa4f3-5023-49dc-bcb2-63bfa2580ccf">
