### PR TITLE
Feature/계정 정보 수정 모달 - 탈퇴하기 #679

### DIFF
--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -66,6 +66,13 @@ const useEditPasswordMutation = () => {
   return useMutation(fetcher);
 };
 
+const useWithdrawalMutation = () => {
+  const fetcher = ({ rawPassword }: { rawPassword: string }) =>
+    axios.patch('/members', { rawPassword }).then(({ data }) => data);
+
+  return useMutation(fetcher);
+};
+
 export {
   useGetProfileQuery,
   useFollowMutation,
@@ -75,4 +82,5 @@ export {
   useNewEmailAuthMutation,
   useEditEmailMutation,
   useEditPasswordMutation,
+  useWithdrawalMutation,
 };

--- a/src/hooks/useGetApiError.ts
+++ b/src/hooks/useGetApiError.ts
@@ -2,6 +2,8 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
+import { useSetRecoilState } from 'recoil';
+import memberState from '@recoil/member.recoil';
 
 type ErrorHandler = (error?: AxiosError) => void;
 
@@ -34,6 +36,7 @@ interface DefaultHttpStatusHandlers extends DefaultHandler {
 
 const useApiError = (handlers?: HttpStatusHandlers) => {
   const navigate = useNavigate();
+  const setMemberState = useSetRecoilState(memberState);
 
   const defaultHandlers: DefaultHttpStatusHandlers = {
     default: () => {
@@ -46,6 +49,7 @@ const useApiError = (handlers?: HttpStatusHandlers) => {
     },
     401: {
       default: () => {
+        setMemberState(null);
         navigate('/login');
       },
     },

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
-import { Divider, Stack, Typography } from '@mui/material';
+import { Button, Divider, Stack, Typography } from '@mui/material';
 
 import { DateTime } from 'luxon';
+import { VscSignOut } from 'react-icons/vsc';
 import { useEditEmailMutation, useEditPasswordMutation, useNewEmailAuthMutation } from '@api/memberApi';
 import { useCheckEmailDuplicationQuery } from '@api/signUpApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { emailRegex } from '@utils/validateEmail';
+import FilledButton from '@components/Button/FilledButton';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import EmailAuthInput from '@components/Input/EmailAuthInput';
 import StandardInput from '@components/Input/StandardInput';
@@ -273,6 +275,15 @@ interface EditAccountModalProps {
 }
 
 const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
+  const [startWithdrawal, setStartWithdrawal] = useState(false);
+
+  const {
+    control,
+    getValues,
+    handleSubmit,
+    formState: { isSubmitting, isValid },
+  } = useForm({ mode: 'onBlur' });
+
   return (
     <ConfirmModal open={open} onClose={onClose} title="계정 정보 수정" modalWidth="md">
       <Stack
@@ -285,6 +296,41 @@ const EditAccountModal = ({ open, onClose }: EditAccountModalProps) => {
         <EditEmailSection />
         <EditPasswordSection />
       </Stack>
+      <Button
+        color="secondary"
+        variant="text"
+        onClick={() => setStartWithdrawal((prev) => !prev)}
+        startIcon={<VscSignOut size={20} className="fill-subRed" />}
+      >
+        <Typography className="align-middle text-subRed">탈퇴하기</Typography>
+      </Button>
+      {startWithdrawal && (
+        <Stack paddingLeft={3} direction="row" alignItems="center" spacing={2}>
+          <Controller
+            name="rawPassword"
+            defaultValue=""
+            control={control}
+            rules={{
+              required: '필수 정보입니다.',
+            }}
+            render={({ field, fieldState: { error } }) => {
+              return (
+                <StandardInput
+                  className="h-16"
+                  type="password"
+                  label="현재 비밀번호"
+                  {...field}
+                  error={Boolean(error)}
+                  helperText={error?.message}
+                />
+              );
+            }}
+          />
+          <FilledButton small disabled={!isValid}>
+            탈퇴
+          </FilledButton>
+        </Stack>
+      )}
     </ConfirmModal>
   );
 };


### PR DESCRIPTION
## 연관 이슈
- Close #679 

## 작업 요약
- 탈퇴 기능 추가하였습니다.

## 작업 상세 설명
- 탈퇴 기능 구현하고, 탈퇴 시 localstorage 멤버 정보 지워주고, 메인페이지로 이동하도록 처리하였습니다.

## 리뷰 요구사항
- 5분
- 현재 탈퇴 시 500에러 발생하는데 백엔드쪽에 문제 전달하였고, 수정 해주시기로 하였습니다!

## Preview 이미지
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/f7c8c73c-0843-44dc-9041-116f5c9cd568">
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/57d5fcd1-9e3b-414d-8b44-03b2d922f743">
