### PR TITLE
Feature/헤더 사이드바 반응형 #700

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -4,6 +4,7 @@ import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
 import { VscAccount, VscGithubInverted, VscThreeBars } from 'react-icons/vsc';
 import { useRecoilValue } from 'recoil';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
+import { HEADER_HEIGHT } from '@constants/keeperTheme';
 import memberState from '@recoil/member.recoil';
 import FilledButton from '@components/Button/FilledButton';
 import AccountMenu from './Menu/AccountMenu';
@@ -28,8 +29,8 @@ const Header = () => {
   return (
     <AppBar
       position="fixed"
-      className="h-header border-b border-pointBlue !bg-mainBlack !bg-none"
-      sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+      className="h-14 border-b border-pointBlue !bg-mainBlack !bg-none sm:h-header"
+      sx={{ zIndex: (theme) => theme.zIndex.drawer + 1, height: HEADER_HEIGHT }}
     >
       <Toolbar className="flex items-center justify-between">
         <div className="flex items-center">
@@ -55,7 +56,7 @@ const Header = () => {
               <IconButton target="_blank" href="https://github.com/KEEPER31337">
                 <VscGithubInverted fill="#4CEEF9" />
               </IconButton>
-              <IconButton onClick={handleAccountIconClick}>
+              <IconButton edge="end" onClick={handleAccountIconClick}>
                 <VscAccount fill="#4CEEF9" />
               </IconButton>
             </div>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -9,10 +9,10 @@ import FilledButton from '@components/Button/FilledButton';
 import AccountMenu from './Menu/AccountMenu';
 
 const Header = () => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const userInfo = useRecoilValue(memberState);
-  const open = Boolean(anchorEl);
+  const profileMenuOpen = Boolean(anchorEl);
 
   const handleDrawerToggle = () => {
     setMobileSidebarOpen(!mobileSidebarOpen);
@@ -59,7 +59,7 @@ const Header = () => {
                 <VscAccount fill="#4CEEF9" />
               </IconButton>
             </div>
-            <AccountMenu userInfo={userInfo} anchorEl={anchorEl} open={open} onClose={handleMenuClose} />
+            <AccountMenu userInfo={userInfo} anchorEl={anchorEl} open={profileMenuOpen} onClose={handleMenuClose} />
           </>
         ) : (
           <Link to="/login">

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
-import { VscAccount, VscGithubInverted } from 'react-icons/vsc';
+import { VscAccount, VscGithubInverted, VscThreeBars } from 'react-icons/vsc';
 import { useRecoilValue } from 'recoil';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import memberState from '@recoil/member.recoil';
@@ -10,8 +10,13 @@ import AccountMenu from './Menu/AccountMenu';
 
 const Header = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const userInfo = useRecoilValue(memberState);
   const open = Boolean(anchorEl);
+
+  const handleDrawerToggle = () => {
+    setMobileSidebarOpen(!mobileSidebarOpen);
+  };
 
   const handleAccountIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -26,10 +31,21 @@ const Header = () => {
       className="h-header border-b border-pointBlue !bg-mainBlack !bg-none"
       sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
     >
-      <Toolbar className="flex justify-between">
-        <Link to="/">
-          <Logo className="h-8" />
-        </Link>
+      <Toolbar className="flex items-center justify-between">
+        <div className="flex items-center">
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            sx={{ mr: { xs: 1, sm: 2 }, display: { lg: 'none' } }}
+          >
+            <VscThreeBars />
+          </IconButton>
+          <Link to="/">
+            <Logo className="h-6 sm:h-8" />
+          </Link>
+        </div>
         {userInfo ? (
           <>
             <div>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -9,14 +9,17 @@ import memberState from '@recoil/member.recoil';
 import FilledButton from '@components/Button/FilledButton';
 import AccountMenu from './Menu/AccountMenu';
 
-const Header = () => {
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+interface HeaderProps {
+  setMobileSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const Header = ({ setMobileSidebarOpen }: HeaderProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const userInfo = useRecoilValue(memberState);
   const profileMenuOpen = Boolean(anchorEl);
 
   const handleDrawerToggle = () => {
-    setMobileSidebarOpen(!mobileSidebarOpen);
+    setMobileSidebarOpen((prev) => !prev);
   };
 
   const handleAccountIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { Outlet } from 'react-router-dom';
 
@@ -6,10 +6,12 @@ import Header from './Header';
 import Sidebar from './Sidebar';
 
 const MainLayout = () => {
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
   return (
     <div className="flex">
-      <Header />
-      <Sidebar />
+      <Header setMobileSidebarOpen={setMobileSidebarOpen} />
+      <Sidebar mobileSidebarOpen={mobileSidebarOpen} setMobileSidebarOpen={setMobileSidebarOpen} />
       <Outlet />
       <Toaster position="top-left" />
     </div>

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { Drawer, Toolbar } from '@mui/material';
+import { Drawer, Toolbar, useMediaQuery, useTheme } from '@mui/material';
 import { Role } from '@api/dto';
 import CATEGORIES from '@constants/category';
 import { KEEPER_COLOR, SIDEBAR_WIDTH } from '@constants/keeperTheme';
 import useCheckAuth from '@hooks/useCheckAuth';
 import CategoryNav from '@components/Navigation/CategoryNav';
 
-const Sidebar = () => {
+interface SidebarProps {
+  mobileSidebarOpen: boolean;
+  setMobileSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const Sidebar = ({ mobileSidebarOpen, setMobileSidebarOpen }: SidebarProps) => {
   const executiveRoles: Role[] = ['ROLE_회장', 'ROLE_부회장', 'ROLE_서기', 'ROLE_총무', 'ROLE_사서'];
   const { checkIncludeOneOfAuths } = useCheckAuth();
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
 
   return (
     <Drawer
       className="h-screen w-sidebar"
-      variant="permanent"
+      variant={isMobile ? 'temporary' : 'permanent'}
+      open={mobileSidebarOpen}
+      onClose={() => setMobileSidebarOpen(false)}
       sx={{
-        display: { lg: 'block', xs: 'none' },
         [`& .MuiDrawer-paper`]: { width: SIDEBAR_WIDTH, bgcolor: KEEPER_COLOR.mainBlack },
       }}
     >

--- a/src/constants/keeperTheme.ts
+++ b/src/constants/keeperTheme.ts
@@ -8,3 +8,4 @@ export const KEEPER_COLOR = {
 };
 
 export const SIDEBAR_WIDTH = 240;
+export const HEADER_HEIGHT = { xs: 56, sm: 66 };


### PR DESCRIPTION
## 연관 이슈
- Close #700

## 작업 요약
- 헤더 사이드바 반응형에 따른 처리 해주었습니다.

## 작업 상세 설명
- 헤더에 사이드바 열고 닫을 수 있는 버튼 추가해주었습니다. 기본 웹뷰에서는 고정해두고, lg 사이즈 이하 부터 열고 닫을 수 있도록 해주었습니다.

## 리뷰 요구사항
- 7분

## Preview 이미지

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/b9a80b31-2d63-4b7f-aea4-3345d587f9b0

