### PR TITLE
refector : AutoComplete z index 제거

### DIFF
--- a/src/components/Input/AutoComplete.tsx
+++ b/src/components/Input/AutoComplete.tsx
@@ -66,7 +66,7 @@ const AutoComplete = <Multiple extends boolean | undefined = false>({
             label={option.label}
             {...getTagProps({ index })}
             disabled={option?.fixed}
-            className="!-z-10 !flex !h-[22px] !w-fit !items-center !rounded-[4px] !bg-pointBlue !bg-opacity-30 !px-1 !py-[2px] !text-[12px] font-semibold"
+            className="!flex !h-[22px] !w-fit !items-center !rounded-[4px] !bg-pointBlue !bg-opacity-30 !px-1 !py-[2px] !text-[12px] font-semibold"
           />
         ))
       }

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -5,8 +5,8 @@ import { SiNotion } from 'react-icons/si';
 import { VscGithubInverted, VscLink } from 'react-icons/vsc';
 
 import { useRecoilValue } from 'recoil';
-import { useGetMemberInfoQuery } from '@api/dutyManageApi';
 import { PeriodicInfo } from '@api/dto';
+import { useGetMemberInfoQuery } from '@api/dutyManageApi';
 import { useAddStudyMutation } from '@api/studyApi';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import memberState from '@recoil/member.recoil';
@@ -154,7 +154,7 @@ const StudyModal = ({ open, setOpen, modalInfo, currentPeriod }: StudyModalProps
         <div className="w-[280px] space-y-2">
           <InputLabel className="!font-semibold">스터디장</InputLabel>
           <AutoComplete
-            className="flex space-x-2 pb-[6px]"
+            className="!-z-10 flex space-x-2 pb-[6px]"
             value={leaderId}
             items={members?.map((member) => ({
               value: member.memberId,
@@ -172,7 +172,7 @@ const StudyModal = ({ open, setOpen, modalInfo, currentPeriod }: StudyModalProps
         <div className="w-full space-y-2">
           <InputLabel className="!font-semibold">스터디원</InputLabel>
           <AutoComplete
-            className="flex space-x-2 pb-[6px]"
+            className="!-z-10 flex space-x-2 pb-[6px]"
             multiple
             grouped
             value={memberIds}

--- a/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
+++ b/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
@@ -96,7 +96,7 @@ const ChangeRolePersonModal = ({ open, toggleOpen, jobName, badgeImage }: Change
       <div className="flex items-center">
         <img className="w-[150px]" alt={jobName} src={badgeImage} />
         <AutoComplete
-          className="mx-12 w-60"
+          className="!-z-10 mx-12 w-60"
           items={sortedOptions}
           value={value}
           grouped

--- a/src/pages/admin/MeritManage/Modal/AddMeritModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/AddMeritModal.tsx
@@ -69,7 +69,7 @@ const AddMeritModal = ({ open, onClose }: AddMeritModalProps) => {
         <div>
           <Typography>회원</Typography>
           <AutoComplete
-            className="w-full"
+            className="!-z-10 w-full"
             value={meritInfo.awarders}
             multiple
             onChange={(v) => {


### PR DESCRIPTION
## 연관 이슈
#713

AutoComplete z index 제거

## 작업 상세 설명
- eslint 오류수정
- AutoComplete z index 제거, 페이지에서 안보이는 문제 해결
- 모달창에서 사용할 경우 모달창을 안넘어가려면 -10 적용

## 리뷰 요구사항
2분
