### PR TITLE
design : 랭킹페이지 반응형 처리

### DIFF
--- a/src/pages/rank/Rank.tsx
+++ b/src/pages/rank/Rank.tsx
@@ -34,7 +34,7 @@ const attendColumns: Column<AttendRankRow>[] = [
   { key: 'rank', headerName: '랭킹' },
   { key: 'realName', headerName: '이름' },
   { key: 'generation', headerName: '기수' },
-  { key: 'continuousDay', headerName: '출석' },
+  { key: 'continuousDay', headerName: '총 출석일' },
   { key: 'time', headerName: '출석 시간' },
 ];
 
@@ -59,7 +59,7 @@ const AttendRankChildComponent = ({ key, value }: ChildComponent<AttendRankRow>)
     case 'generation':
       return `${value}기`;
     case 'continuousDay':
-      return `${value}일째 출석 중`;
+      return `${value}일`;
     default:
       return value;
   }
@@ -132,7 +132,7 @@ const Rank = () => {
             />
           )}
         </div>
-        <div className="flex min-h-[45rem] w-full flex-col px-10 lg:ml-5 lg:w-1/3 lg:px-0">
+        <div className="mb-48 flex w-full flex-col px-10 lg:mb-0 lg:ml-5 lg:min-h-[45rem] lg:w-1/3 lg:px-0">
           <Typography marginBottom={2.5} variant="h3" fontWeight="semibold" className="text-center">
             {tab === 0 && '개근왕'}
             {tab === 1 && '오늘의 게임왕'}


### PR DESCRIPTION
## 연관 이슈
#685

## 작업 요약
랭킹페이지 반응형 처리

## 작업 상세 설명
- lg 이하일시 세로정렬
- lg 이하일시 TapCatd 목록 높이 조절

## 리뷰 요구사항
2분
기존에 어느정도 반응형이 되어 있어 큰 작업은 없습니다.
기존에 있던 반응형 적절한지 확인 부탁드립니다.

## Preview 이미지
<img width="447" alt="스크린샷 2023-09-24 오후 4 53 25" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/51306225/c9df10ce-9974-46f3-a7f4-823a9985db35">
