### PR TITLE
Feature/활동인원 관리 페이지 구현 #702

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -16,6 +16,8 @@ export type Role =
   | 'ROLE_회원'
   | 'ROLE_출제자';
 
+export type MemberType = '비회원' | '정회원' | '휴면회원' | '졸업' | '탈퇴';
+
 export interface MemberInfo {
   memberId: number;
   loginId: number;
@@ -32,7 +34,7 @@ export interface MemberDetailInfo extends MemberInfo {
   point: number;
   level: number;
   totalAttendance: number;
-  memberType: string;
+  memberType: MemberType;
   memberRank: string;
 }
 
@@ -559,7 +561,7 @@ export interface ProfileInfo {
   emailAddress: string;
   thumbnailPath: string | null;
   point: number;
-  memberType: string;
+  memberType: MemberType;
   memberJobs: Role[];
   follower: FollowInfo[];
   followee: FollowInfo[];

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -1,10 +1,28 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import axios from 'axios';
 import { formatGeneration } from '@utils/converter';
-import { ProfileInfo } from './dto';
+import { ProfileInfo, MemberDetailInfo } from './dto';
 
+const memberKeys = {
+  memberList: ['member', 'memberList'] as const,
+};
 const profileKeys = {
   profileInfo: (memberId: number) => ['profile', 'profileInfo', memberId] as const,
+};
+
+const useGetMembersQuery = ({ searchName, onSuccess }: { searchName?: string; onSuccess?: any }) => {
+  const fetcher = () =>
+    axios.get('/members/real-name', { params: { searchName } }).then(({ data }) => {
+      return data.map((memberInfo: MemberDetailInfo) => {
+        return {
+          ...memberInfo,
+          generation: formatGeneration(memberInfo.generation),
+        };
+      });
+    });
+  return useQuery<MemberDetailInfo[]>(memberKeys.memberList, fetcher, {
+    onSuccess,
+  });
 };
 
 const useGetProfileQuery = (memberId: number) => {
@@ -96,6 +114,7 @@ const useEditPasswordMutation = () => {
 };
 
 export {
+  useGetMembersQuery,
   useGetProfileQuery,
   useFollowMemberMutation,
   useUnFollowMemberMutation,

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -10,7 +10,13 @@ const profileKeys = {
   profileInfo: (memberId: number) => ['profile', 'profileInfo', memberId] as const,
 };
 
-const useGetMembersQuery = ({ searchName, onSuccess }: { searchName?: string; onSuccess?: any }) => {
+const useGetMembersQuery = ({
+  searchName,
+  onSuccess,
+}: {
+  searchName?: string;
+  onSuccess?: (data: MemberDetailInfo[]) => void;
+}) => {
   const fetcher = () =>
     axios.get('/members/real-name', { params: { searchName } }).then(({ data }) => {
       return data.map((memberInfo: MemberDetailInfo) => {

--- a/src/api/memberApi.ts
+++ b/src/api/memberApi.ts
@@ -126,6 +126,18 @@ const useWithdrawalMutation = () => {
   return useMutation(fetcher);
 };
 
+const useEditMemberTypeMutation = () => {
+  const queryClient = useQueryClient();
+  const fetcher = ({ typeId, memberIds }: { typeId: number; memberIds: number[] }) =>
+    axios.patch(`/members/types/${typeId}`, { memberIds });
+
+  return useMutation(fetcher, {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.memberList });
+    },
+  });
+};
+
 export {
   useGetMembersQuery,
   useGetProfileQuery,
@@ -137,4 +149,5 @@ export {
   useEditEmailMutation,
   useEditPasswordMutation,
   useWithdrawalMutation,
+  useEditMemberTypeMutation,
 };

--- a/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
+++ b/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
@@ -1,54 +1,24 @@
-import React, { useState, useEffect } from 'react';
-import { Typography } from '@mui/material';
-import { MemberDetailInfo, MemberType } from '@api/dto';
+import React, { useState } from 'react';
+import { MemberDetailInfo } from '@api/dto';
 import { useGetMembersQuery } from '@api/memberApi';
-import OutlinedButton from '@components/Button/OutlinedButton';
-import AutoComplete, { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
-import Selector from '@components/Selector/Selector';
+import { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
 import PageTitle from '@components/Typography/PageTitle';
-import MemberCard from './MemberCard';
+import ChangeMemberTypeButton from './Button/ChangeMemberTypeButton';
+import ChangeMemberTypeInput from './Input/ChangeMemberTypeInput';
+import MemberTypeSection from './Section/MemberTypeSection';
+import SortSelector from './Selector/SortSelector';
 
-type SortInfo = {
-  generation: string;
-  realName: string;
-};
+const memberTypeList = [
+  { type: '정회원', renderType: '활동회원', typeId: 2, color: 'pointBlue' },
+  { type: '휴면회원', renderType: '휴면', typeId: 3, color: 'white' },
+  { type: '졸업', renderType: '졸업', typeId: 4, color: 'mainBlack' },
+  { type: '비회원', renderType: '비회원', typeId: 1, color: '' },
+  { type: '탈퇴', renderType: '탈퇴', typeId: 5, color: 'subRed' },
+];
 
 const ActiveMemberManage = () => {
   const [selectedMemberList, setSelectedMemberList] = useState<MultiAutoCompleteValue>([]);
-  const [sortInfo, setSortInfo] = useState<SortInfo>({
-    generation: '내림차순',
-    realName: '가나다순',
-  });
   const [memberList, setMemberList] = useState<MemberDetailInfo[]>([]);
-
-  const memberTypeList = [
-    { type: '활동회원', typeId: 2, color: 'pointBlue' },
-    { type: '휴면', typeId: 3, color: 'amber-300' },
-    { type: '졸업', typeId: 4, color: 'black' },
-    { type: '비회원', typeId: 1, color: 'white' },
-    { type: '탈퇴', typeId: 5, color: '' },
-  ];
-
-  const generationSearchList = [
-    {
-      id: '내림차순',
-      content: '내림차순',
-    },
-    {
-      id: '오름차순',
-      content: '오름차순',
-    },
-  ];
-  const realNameSearchList = [
-    {
-      id: '가나다순',
-      content: '가나다순',
-    },
-    {
-      id: '역순',
-      content: '역순',
-    },
-  ];
 
   const { data: originMemberList } = useGetMembersQuery({
     onSuccess: (data: MemberDetailInfo[]) => {
@@ -56,158 +26,23 @@ const ActiveMemberManage = () => {
     },
   });
 
-  const sortMemberList = ({ generation, realName }: SortInfo) => {
-    const sortedList = [...memberList]
-      .sort((a, b) => {
-        const aRealName = a.realName;
-        const bRealName = b.realName;
-        return realName === '가나다순' ? aRealName.localeCompare(bRealName) : bRealName.localeCompare(aRealName);
-      })
-      .sort((a, b) => {
-        const aGeneration = parseFloat(a.generation);
-        const bGeneration = parseFloat(b.generation);
-        return generation === '내림차순' ? bGeneration - aGeneration : aGeneration - bGeneration;
-      });
-
-    setMemberList(sortedList);
-  };
-
-  const toggleMemberSelection = (memberInfo: MemberDetailInfo) => {
-    setSelectedMemberList((prevSelectedMembers: any) => {
-      const isMemberSelected = prevSelectedMembers.some((member: any) => member.value === memberInfo.memberId);
-      return isMemberSelected
-        ? prevSelectedMembers.filter((member: any) => member.value !== memberInfo.memberId)
-        : [
-            ...prevSelectedMembers,
-            { value: memberInfo.memberId, label: `${memberInfo.realName} (${memberInfo.generation})` },
-          ];
-    });
-  };
-
   return (
     <div>
       <PageTitle>활동 인원 관리</PageTitle>
-      <div className="mb-5 flex space-x-2">
-        <div className="flex justify-start space-x-2">
-          <Selector
-            className="w-32"
-            label="기수"
-            value={sortInfo.generation}
-            onChange={(e) => {
-              const generationSortInfo = e.target.value as string;
-              setSortInfo((prev) => ({ ...prev, generation: generationSortInfo }));
-              sortMemberList({ generation: generationSortInfo, realName: sortInfo.realName });
-            }}
-            options={generationSearchList}
-          />
-          <Selector
-            className="w-32"
-            label="이름"
-            value={sortInfo.realName}
-            onChange={(e) => {
-              const realNameSortInfo = e.target.value as string;
-              setSortInfo((prev) => ({ ...prev, realName: realNameSortInfo }));
-              sortMemberList({ generation: sortInfo.generation, realName: realNameSortInfo });
-            }}
-            options={realNameSearchList}
-          />
-        </div>
-      </div>
-
-      <div className="mb-5 grid grid-cols-6 content-start gap-3">
-        <div className="col-span-2 space-y-2">
-          <div className="flex items-center space-x-2  p-1">
-            <div className="h-4 w-4 rounded-full bg-pointBlue" />
-            <Typography>활동회원</Typography>
-          </div>
-          <div className="grid grid-cols-2 gap-1">
-            {memberList.map((memberInfo) => (
-              <MemberCard
-                key={memberInfo.memberId}
-                memberInfo={memberInfo}
-                onClick={() => toggleMemberSelection(memberInfo)}
-                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
-              />
-            ))}
-          </div>
-        </div>
-        {/* <div className="col-span-2 space-y-2">
-          <div className="flex items-center space-x-2 p-1">
-            <div className="h-4 w-4 rounded-full bg-amber-300" />
-            <Typography>휴면</Typography>
-          </div>
-
-          <div className="grid grid-cols-2  gap-1">
-            {memberList.map((memberInfo) => (
-              <MemberCard
-                key={memberInfo.memberId}
-                memberInfo={memberInfo}
-                onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
-              />
-            ))}
-          </div>
-        </div>
-        <div className="col-span-1 space-y-2">
-          <div className="flex items-center space-x-2 p-1">
-            <div className="h-4 w-4 rounded-full bg-black" />
-            <Typography>졸업</Typography>
-          </div>
-          <div className="grid gap-1">
-            {memberList.map((memberInfo) => (
-              <MemberCard
-                key={memberInfo.memberId}
-                memberInfo={memberInfo}
-                onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
-              />
-            ))}
-          </div>
-        </div>
-
-        <div className="col-span-1 space-y-2">
-          <div className="flex items-center space-x-2 p-1">
-            <div className="h-4 w-4 rounded-full bg-white" />
-            <Typography>비회원</Typography>
-          </div>
-          <div className="grid gap-1">
-            {memberList.map((memberInfo) => (
-              <MemberCard
-                key={memberInfo.memberId}
-                memberInfo={memberInfo}
-                onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
-              />
-            ))}
-          </div>
-        </div> */}
-      </div>
+      <SortSelector memberList={memberList} setMemberList={setMemberList} />
+      <MemberTypeSection
+        memberTypeList={memberTypeList}
+        memberList={memberList}
+        selectedMemberList={selectedMemberList}
+        setSelectedMemberList={setSelectedMemberList}
+      />
       <div className="flex justify-between">
-        {selectedMemberList && (
-          <AutoComplete
-            className="w-96"
-            value={selectedMemberList}
-            multiple
-            onChange={setSelectedMemberList}
-            items={originMemberList?.map((member) => ({
-              value: member.memberId,
-              label: `${member.realName} (${member.generation})`,
-            }))}
-          />
-        )}
-        <div className="flex space-x-2">
-          {memberTypeList.map((member) => (
-            <OutlinedButton
-              key={member.typeId}
-              onClick={() => {
-                console.log(member.typeId, '선택한 인원 : ', selectedMemberList);
-              }}
-            >
-              {member.color && <div className={`bg-${member.color}  mr-2 h-4 w-4 rounded-full`} />}
-              <Typography>{member.type}</Typography>
-            </OutlinedButton>
-          ))}
-        </div>
+        <ChangeMemberTypeInput
+          memberList={memberList}
+          selectedMemberList={selectedMemberList}
+          setSelectedMemberList={setSelectedMemberList}
+        />
+        <ChangeMemberTypeButton memberTypeList={memberTypeList} selectedMemberList={selectedMemberList} />
       </div>
     </div>
   );

--- a/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
+++ b/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
@@ -1,0 +1,226 @@
+import React, { useState, useEffect } from 'react';
+import { Typography } from '@mui/material';
+import { MemberDetailInfo, MemberType } from '@api/dto';
+import { useGetMembersQuery } from '@api/memberApi';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import AutoComplete, { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
+import Selector from '@components/Selector/Selector';
+import PageTitle from '@components/Typography/PageTitle';
+import MemberCard from './MemberCard';
+
+type SortInfo = {
+  generation: string;
+  realName: string;
+};
+type MeritInfo = {
+  awarders: MultiAutoCompleteValue;
+  meritTypeId: number;
+};
+
+const ActiveMemberManage = () => {
+  const [meritInfo, setMeritInfo] = useState<MeritInfo>({
+    awarders: [],
+    meritTypeId: 0,
+  });
+
+  const [sortInfo, setSortInfo] = useState<SortInfo>({
+    generation: '내림차순',
+    realName: '가나다순',
+  });
+  const memberTypeId = [
+    { type: '활동회원', id: 2, color: 'pointBlue' },
+    { type: '휴면', id: 3, color: 'amber-300' },
+    { type: '졸업', id: 4, color: 'black' },
+    { type: '비회원', id: 1, color: 'white' },
+    { type: '탈퇴', id: 5, color: '' },
+  ];
+  const [memberList, setMemberList] = useState<MemberDetailInfo[]>([]);
+  const [selectedMemberList, setSelectedMemberList] = useState<MemberDetailInfo[]>([]);
+
+  console.log('meritInfo', meritInfo);
+  const generationSearchList = [
+    {
+      id: '내림차순',
+      content: '내림차순',
+    },
+    {
+      id: '오름차순',
+      content: '오름차순',
+    },
+  ];
+  const realNameSearchList = [
+    {
+      id: '가나다순',
+      content: '가나다순',
+    },
+    {
+      id: '역순',
+      content: '역순',
+    },
+  ];
+
+  const { data: originMemberList } = useGetMembersQuery({
+    onSuccess: (data: MemberDetailInfo[]) => {
+      setMemberList(data);
+    },
+  });
+
+  const sortMemberList = ({ generation, realName }: SortInfo) => {
+    const sortedList = [...memberList]
+      .sort((a, b) => {
+        const aRealName = a.realName;
+        const bRealName = b.realName;
+        return realName === '가나다순' ? aRealName.localeCompare(bRealName) : bRealName.localeCompare(aRealName);
+      })
+      .sort((a, b) => {
+        const aGeneration = parseFloat(a.generation);
+        const bGeneration = parseFloat(b.generation);
+        return generation === '내림차순' ? bGeneration - aGeneration : aGeneration - bGeneration;
+      });
+
+    setMemberList(sortedList);
+  };
+
+  const toggleMemberSelection = (memberId: number) => {
+    setSelectedMemberList((prevSelectedMembers: any) => {
+      const isMemberSelected = prevSelectedMembers.some((member: MemberDetailInfo) => member.memberId === memberId);
+      return isMemberSelected
+        ? prevSelectedMembers.filter((member: MemberDetailInfo) => member.memberId !== memberId)
+        : [...prevSelectedMembers, memberList.find((member) => member.memberId === memberId)];
+    });
+  };
+
+  return (
+    <div>
+      <PageTitle>활동 인원 관리</PageTitle>
+      <div className="mb-5 flex space-x-2">
+        <div className="flex justify-start space-x-2">
+          <Selector
+            className="w-32"
+            label="기수"
+            value={sortInfo.generation}
+            onChange={(e) => {
+              const generationSortInfo = e.target.value as string;
+              setSortInfo((prev) => ({ ...prev, generation: generationSortInfo }));
+              sortMemberList({ generation: generationSortInfo, realName: sortInfo.realName });
+            }}
+            options={generationSearchList}
+          />
+          <Selector
+            className="w-32"
+            label="이름"
+            value={sortInfo.realName}
+            onChange={(e) => {
+              const realNameSortInfo = e.target.value as string;
+              setSortInfo((prev) => ({ ...prev, realName: realNameSortInfo }));
+              sortMemberList({ generation: sortInfo.generation, realName: realNameSortInfo });
+            }}
+            options={realNameSearchList}
+          />
+        </div>
+      </div>
+
+      <div className="mb-5 grid grid-cols-6 content-start gap-3">
+        <div className="col-span-2 space-y-2">
+          <div className="flex items-center space-x-2  p-1">
+            <div className="h-4 w-4 rounded-full bg-pointBlue" />
+            <Typography>활동회원</Typography>
+          </div>
+          <div className="grid grid-cols-2 gap-1">
+            {memberList.map((memberInfo) => (
+              <MemberCard
+                key={memberInfo.memberId}
+                memberInfo={memberInfo}
+                onClick={() => toggleMemberSelection(memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="col-span-2 space-y-2">
+          <div className="flex items-center space-x-2 p-1">
+            <div className="h-4 w-4 rounded-full bg-amber-300" />
+            <Typography>휴면</Typography>
+          </div>
+
+          <div className="grid grid-cols-2  gap-1">
+            {memberList.map((memberInfo) => (
+              <MemberCard
+                key={memberInfo.memberId}
+                memberInfo={memberInfo}
+                onClick={() => toggleMemberSelection(memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="col-span-1 space-y-2">
+          <div className="flex items-center space-x-2 p-1">
+            <div className="h-4 w-4 rounded-full bg-black" />
+            <Typography>졸업</Typography>
+          </div>
+          <div className="grid gap-1">
+            {memberList.map((memberInfo) => (
+              <MemberCard
+                key={memberInfo.memberId}
+                memberInfo={memberInfo}
+                onClick={() => toggleMemberSelection(memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="col-span-1 space-y-2">
+          <div className="flex items-center space-x-2 p-1">
+            <div className="h-4 w-4 rounded-full bg-white" />
+            <Typography>비회원</Typography>
+          </div>
+          <div className="grid gap-1">
+            {memberList.map((memberInfo) => (
+              <MemberCard
+                key={memberInfo.memberId}
+                memberInfo={memberInfo}
+                onClick={() => toggleMemberSelection(memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-between">
+        {console.log('===meritInfo.awarders===', meritInfo.awarders)}
+        {meritInfo.awarders && (
+          <AutoComplete
+            className="w-96"
+            value={meritInfo.awarders}
+            multiple
+            onChange={(v) => {
+              setMeritInfo((prev) => ({ ...prev, awarders: v }));
+            }}
+            items={originMemberList?.map((member) => ({
+              value: member.memberId,
+              label: `${member.realName} (${member.generation})`,
+              group: `s`,
+            }))}
+          />
+        )}
+        <div className="flex space-x-2">
+          {memberTypeId.map((member) => (
+            <OutlinedButton
+              key={member.id}
+              onClick={() => {
+                console.log(member.id, '선택한 인원 : ', selectedMemberList);
+              }}
+            >
+              {member.color && <div className={`bg-${member.color}  mr-2 h-4 w-4 rounded-full`} />}
+              <Typography>{member.type}</Typography>
+            </OutlinedButton>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActiveMemberManage;

--- a/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
+++ b/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
@@ -20,7 +20,7 @@ const ActiveMemberManage = () => {
   const [selectedMemberList, setSelectedMemberList] = useState<MultiAutoCompleteValue>([]);
   const [memberList, setMemberList] = useState<MemberDetailInfo[]>([]);
 
-  const { data: originMemberList } = useGetMembersQuery({
+  useGetMembersQuery({
     onSuccess: (data: MemberDetailInfo[]) => {
       setMemberList(data);
     },
@@ -42,7 +42,11 @@ const ActiveMemberManage = () => {
           selectedMemberList={selectedMemberList}
           setSelectedMemberList={setSelectedMemberList}
         />
-        <ChangeMemberTypeButton memberTypeList={memberTypeList} selectedMemberList={selectedMemberList} />
+        <ChangeMemberTypeButton
+          memberTypeList={memberTypeList}
+          selectedMemberList={selectedMemberList}
+          setSelectedMemberList={setSelectedMemberList}
+        />
       </div>
     </div>
   );

--- a/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
+++ b/src/pages/admin/ActiveMemberManage/ActiveMemberManage.tsx
@@ -12,32 +12,23 @@ type SortInfo = {
   generation: string;
   realName: string;
 };
-type MeritInfo = {
-  awarders: MultiAutoCompleteValue;
-  meritTypeId: number;
-};
 
 const ActiveMemberManage = () => {
-  const [meritInfo, setMeritInfo] = useState<MeritInfo>({
-    awarders: [],
-    meritTypeId: 0,
-  });
-
+  const [selectedMemberList, setSelectedMemberList] = useState<MultiAutoCompleteValue>([]);
   const [sortInfo, setSortInfo] = useState<SortInfo>({
     generation: '내림차순',
     realName: '가나다순',
   });
-  const memberTypeId = [
-    { type: '활동회원', id: 2, color: 'pointBlue' },
-    { type: '휴면', id: 3, color: 'amber-300' },
-    { type: '졸업', id: 4, color: 'black' },
-    { type: '비회원', id: 1, color: 'white' },
-    { type: '탈퇴', id: 5, color: '' },
-  ];
   const [memberList, setMemberList] = useState<MemberDetailInfo[]>([]);
-  const [selectedMemberList, setSelectedMemberList] = useState<MemberDetailInfo[]>([]);
 
-  console.log('meritInfo', meritInfo);
+  const memberTypeList = [
+    { type: '활동회원', typeId: 2, color: 'pointBlue' },
+    { type: '휴면', typeId: 3, color: 'amber-300' },
+    { type: '졸업', typeId: 4, color: 'black' },
+    { type: '비회원', typeId: 1, color: 'white' },
+    { type: '탈퇴', typeId: 5, color: '' },
+  ];
+
   const generationSearchList = [
     {
       id: '내림차순',
@@ -81,12 +72,15 @@ const ActiveMemberManage = () => {
     setMemberList(sortedList);
   };
 
-  const toggleMemberSelection = (memberId: number) => {
+  const toggleMemberSelection = (memberInfo: MemberDetailInfo) => {
     setSelectedMemberList((prevSelectedMembers: any) => {
-      const isMemberSelected = prevSelectedMembers.some((member: MemberDetailInfo) => member.memberId === memberId);
+      const isMemberSelected = prevSelectedMembers.some((member: any) => member.value === memberInfo.memberId);
       return isMemberSelected
-        ? prevSelectedMembers.filter((member: MemberDetailInfo) => member.memberId !== memberId)
-        : [...prevSelectedMembers, memberList.find((member) => member.memberId === memberId)];
+        ? prevSelectedMembers.filter((member: any) => member.value !== memberInfo.memberId)
+        : [
+            ...prevSelectedMembers,
+            { value: memberInfo.memberId, label: `${memberInfo.realName} (${memberInfo.generation})` },
+          ];
     });
   };
 
@@ -131,13 +125,13 @@ const ActiveMemberManage = () => {
               <MemberCard
                 key={memberInfo.memberId}
                 memberInfo={memberInfo}
-                onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+                onClick={() => toggleMemberSelection(memberInfo)}
+                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
               />
             ))}
           </div>
         </div>
-        <div className="col-span-2 space-y-2">
+        {/* <div className="col-span-2 space-y-2">
           <div className="flex items-center space-x-2 p-1">
             <div className="h-4 w-4 rounded-full bg-amber-300" />
             <Typography>휴면</Typography>
@@ -149,7 +143,7 @@ const ActiveMemberManage = () => {
                 key={memberInfo.memberId}
                 memberInfo={memberInfo}
                 onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
               />
             ))}
           </div>
@@ -165,7 +159,7 @@ const ActiveMemberManage = () => {
                 key={memberInfo.memberId}
                 memberInfo={memberInfo}
                 onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
               />
             ))}
           </div>
@@ -182,35 +176,31 @@ const ActiveMemberManage = () => {
                 key={memberInfo.memberId}
                 memberInfo={memberInfo}
                 onClick={() => toggleMemberSelection(memberInfo.memberId)}
-                isSelected={selectedMemberList.some((member) => member.memberId === memberInfo.memberId)}
+                isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
               />
             ))}
           </div>
-        </div>
+        </div> */}
       </div>
       <div className="flex justify-between">
-        {console.log('===meritInfo.awarders===', meritInfo.awarders)}
-        {meritInfo.awarders && (
+        {selectedMemberList && (
           <AutoComplete
             className="w-96"
-            value={meritInfo.awarders}
+            value={selectedMemberList}
             multiple
-            onChange={(v) => {
-              setMeritInfo((prev) => ({ ...prev, awarders: v }));
-            }}
+            onChange={setSelectedMemberList}
             items={originMemberList?.map((member) => ({
               value: member.memberId,
               label: `${member.realName} (${member.generation})`,
-              group: `s`,
             }))}
           />
         )}
         <div className="flex space-x-2">
-          {memberTypeId.map((member) => (
+          {memberTypeList.map((member) => (
             <OutlinedButton
-              key={member.id}
+              key={member.typeId}
               onClick={() => {
-                console.log(member.id, '선택한 인원 : ', selectedMemberList);
+                console.log(member.typeId, '선택한 인원 : ', selectedMemberList);
               }}
             >
               {member.color && <div className={`bg-${member.color}  mr-2 h-4 w-4 rounded-full`} />}

--- a/src/pages/admin/ActiveMemberManage/Button/ChangeMemberTypeButton.tsx
+++ b/src/pages/admin/ActiveMemberManage/Button/ChangeMemberTypeButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+import OutlinedButton from '@components/Button/OutlinedButton';
+import { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
+
+interface ChangeMemberTypeButtonProps {
+  memberTypeList: Array<{
+    type: string;
+    renderType: string;
+    typeId: number;
+    color?: string;
+  }>;
+  selectedMemberList: MultiAutoCompleteValue;
+}
+
+const ChangeMemberTypeButton = ({ memberTypeList, selectedMemberList }: ChangeMemberTypeButtonProps) => {
+  return (
+    <div className="flex space-x-2">
+      {memberTypeList.map((member) => (
+        <OutlinedButton
+          key={member.typeId}
+          onClick={() => {
+            console.log(member.typeId, '선택한 인원 : ', selectedMemberList);
+          }}
+        >
+          {member.color && <div className={`bg-${member.color} mr-2 h-4 w-4 rounded-full`} />}
+          <Typography>{member.renderType}</Typography>
+        </OutlinedButton>
+      ))}
+    </div>
+  );
+};
+
+export default ChangeMemberTypeButton;

--- a/src/pages/admin/ActiveMemberManage/Button/ChangeMemberTypeButton.tsx
+++ b/src/pages/admin/ActiveMemberManage/Button/ChangeMemberTypeButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography } from '@mui/material';
+import { useEditMemberTypeMutation } from '@api/memberApi';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
 
@@ -11,18 +12,34 @@ interface ChangeMemberTypeButtonProps {
     color?: string;
   }>;
   selectedMemberList: MultiAutoCompleteValue;
+  setSelectedMemberList: React.Dispatch<React.SetStateAction<MultiAutoCompleteValue>>;
 }
 
-const ChangeMemberTypeButton = ({ memberTypeList, selectedMemberList }: ChangeMemberTypeButtonProps) => {
+const ChangeMemberTypeButton = ({
+  memberTypeList,
+  selectedMemberList,
+  setSelectedMemberList,
+}: ChangeMemberTypeButtonProps) => {
+  const { mutate: editMemberTypeMutation } = useEditMemberTypeMutation();
+
+  const handleButtonClick = (typeId: number) => {
+    const memberIds = selectedMemberList.map((item) => item.value as number);
+    editMemberTypeMutation(
+      {
+        memberIds,
+        typeId,
+      },
+      {
+        onSuccess: () => {
+          setSelectedMemberList([]);
+        },
+      },
+    );
+  };
   return (
     <div className="flex space-x-2">
       {memberTypeList.map((member) => (
-        <OutlinedButton
-          key={member.typeId}
-          onClick={() => {
-            console.log(member.typeId, '선택한 인원 : ', selectedMemberList);
-          }}
-        >
+        <OutlinedButton key={member.typeId} onClick={() => handleButtonClick(member.typeId)}>
           {member.color && <div className={`bg-${member.color} mr-2 h-4 w-4 rounded-full`} />}
           <Typography>{member.renderType}</Typography>
         </OutlinedButton>

--- a/src/pages/admin/ActiveMemberManage/Card/MemberCard.tsx
+++ b/src/pages/admin/ActiveMemberManage/Card/MemberCard.tsx
@@ -27,7 +27,7 @@ const MemberCard = ({ memberInfo, onClick, isSelected }: MemberCardProps) => {
         className="mr-1 !h-7 !w-7 !bg-subBlack !text-white "
         src={memberInfo?.thumbnailPath ? getServerImgUrl(memberInfo?.thumbnailPath) : ''}
       />
-      <Typography className="!text-[14px]">{memberInfo.realName}</Typography>{' '}
+      <Typography className="!text-[14px]">{memberInfo.realName}</Typography>
       <Typography variant="small" className="!ml-1">
         ({memberInfo.generation})
       </Typography>

--- a/src/pages/admin/ActiveMemberManage/Input/ChangeMemberTypeInput.tsx
+++ b/src/pages/admin/ActiveMemberManage/Input/ChangeMemberTypeInput.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MemberDetailInfo } from '@api/dto';
+import AutoComplete, { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
+
+interface ChangeMemberTypeInputProps {
+  memberList: MemberDetailInfo[];
+  selectedMemberList: MultiAutoCompleteValue;
+  setSelectedMemberList: React.Dispatch<React.SetStateAction<MultiAutoCompleteValue>>;
+}
+
+const ChangeMemberTypeButton = ({
+  memberList,
+  selectedMemberList,
+  setSelectedMemberList,
+}: ChangeMemberTypeInputProps) => {
+  return (
+    <AutoComplete
+      className="w-96"
+      value={selectedMemberList}
+      multiple
+      onChange={setSelectedMemberList}
+      items={memberList?.map((member) => ({
+        value: member.memberId,
+        label: `${member.realName} (${member.generation})`,
+      }))}
+    />
+  );
+};
+
+export default ChangeMemberTypeButton;

--- a/src/pages/admin/ActiveMemberManage/MemberCard.tsx
+++ b/src/pages/admin/ActiveMemberManage/MemberCard.tsx
@@ -14,7 +14,6 @@ const MemberCard = ({ memberInfo, onClick, isSelected }: MemberCardProps) => {
     onClick();
   };
 
-  console.log(isSelected);
   return (
     <button
       type="button"
@@ -28,10 +27,10 @@ const MemberCard = ({ memberInfo, onClick, isSelected }: MemberCardProps) => {
         className="mr-1 !h-7 !w-7 !bg-subBlack !text-white "
         src={memberInfo?.thumbnailPath ? getServerImgUrl(memberInfo?.thumbnailPath) : ''}
       />
-      <Typography variant="small" className="!mr-1 w-8 text-right">
-        {memberInfo.generation}기
+      <Typography className="!text-[14px]">{memberInfo.realName}</Typography>{' '}
+      <Typography variant="small" className="!ml-1">
+        ({memberInfo.generation})
       </Typography>
-      <Typography className="!text-[14px]">{memberInfo.realName}</Typography>
     </button>
   );
 };

--- a/src/pages/admin/ActiveMemberManage/MemberCard.tsx
+++ b/src/pages/admin/ActiveMemberManage/MemberCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Typography, Avatar } from '@mui/material';
+import { MemberDetailInfo } from '@api/dto';
+import { getServerImgUrl } from '@utils/converter';
+
+interface MemberCardProps {
+  memberInfo: MemberDetailInfo;
+  onClick: () => void;
+  isSelected?: boolean;
+}
+
+const MemberCard = ({ memberInfo, onClick, isSelected }: MemberCardProps) => {
+  const handleCardClick = () => {
+    onClick();
+  };
+
+  console.log(isSelected);
+  return (
+    <button
+      type="button"
+      onClick={handleCardClick}
+      className={`${
+        isSelected && '!border-pointBlue'
+      } flex h-fit items-center border border-transparent bg-middleBlack/50 p-1
+      `}
+    >
+      <Avatar
+        className="mr-1 !h-7 !w-7 !bg-subBlack !text-white "
+        src={memberInfo?.thumbnailPath ? getServerImgUrl(memberInfo?.thumbnailPath) : ''}
+      />
+      <Typography variant="small" className="!mr-1 w-8 text-right">
+        {memberInfo.generation}기
+      </Typography>
+      <Typography className="!text-[14px]">{memberInfo.realName}</Typography>
+    </button>
+  );
+};
+
+export default MemberCard;

--- a/src/pages/admin/ActiveMemberManage/Section/MemberTypeSection.tsx
+++ b/src/pages/admin/ActiveMemberManage/Section/MemberTypeSection.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+import { MemberDetailInfo } from '@api/dto';
+import { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
+import MemberCard from '../Card/MemberCard';
+
+interface MemberCardProps {
+  memberTypeList: Array<{
+    type: string;
+    renderType: string;
+    typeId: number;
+    color?: string;
+  }>;
+  memberList: MemberDetailInfo[];
+  selectedMemberList: MultiAutoCompleteValue;
+  setSelectedMemberList: React.Dispatch<React.SetStateAction<MultiAutoCompleteValue>>;
+}
+
+const MemberTypeSection = ({
+  memberTypeList,
+  memberList,
+  selectedMemberList,
+  setSelectedMemberList,
+}: MemberCardProps) => {
+  const toggleMemberSelection = (memberInfo: MemberDetailInfo) => {
+    setSelectedMemberList((prevSelectedMember: MultiAutoCompleteValue) => {
+      const isSelected = prevSelectedMember.some((member) => member.value === memberInfo.memberId);
+      return isSelected
+        ? prevSelectedMember.filter((member) => member.value !== memberInfo.memberId)
+        : [
+            ...prevSelectedMember,
+            { value: memberInfo.memberId, label: `${memberInfo.realName} (${memberInfo.generation})` },
+          ];
+    });
+  };
+
+  return (
+    <div className="mb-5 grid grid-cols-6 content-start gap-3">
+      {memberTypeList
+        .filter((memberType) => memberType.renderType !== '탈퇴')
+        .map((memberType) => (
+          <div
+            key={memberType.typeId}
+            className={`${
+              memberType.type === '정회원' || memberType.type === '휴면회원' ? 'col-span-2' : 'col-span-1'
+            } space-y-2`}
+          >
+            <div className="flex items-center space-x-2 p-1">
+              <div className={`bg-${memberType.color} mr-2 h-4 w-4 rounded-full`} />
+              <Typography>{memberType.renderType}</Typography>
+            </div>
+            <div className="grid grid-cols-2 gap-1">
+              {memberList
+                .filter((v) => v.memberType === memberType.type)
+                .map((memberInfo) => (
+                  <MemberCard
+                    key={memberInfo.memberId}
+                    memberInfo={memberInfo}
+                    onClick={() => toggleMemberSelection(memberInfo)}
+                    isSelected={selectedMemberList.some((member) => member.value === memberInfo.memberId)}
+                  />
+                ))}
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+};
+
+export default MemberTypeSection;

--- a/src/pages/admin/ActiveMemberManage/Section/MemberTypeSection.tsx
+++ b/src/pages/admin/ActiveMemberManage/Section/MemberTypeSection.tsx
@@ -49,7 +49,11 @@ const MemberTypeSection = ({
               <div className={`bg-${memberType.color} mr-2 h-4 w-4 rounded-full`} />
               <Typography>{memberType.renderType}</Typography>
             </div>
-            <div className="grid grid-cols-2 gap-1">
+            <div
+              className={`${
+                memberType.type === '정회원' || memberType.type === '휴면회원' ? 'grid-cols-2' : 'grid-cols-1'
+              } grid gap-1`}
+            >
               {memberList
                 .filter((v) => v.memberType === memberType.type)
                 .map((memberInfo) => (

--- a/src/pages/admin/ActiveMemberManage/Selector/SortSelector.tsx
+++ b/src/pages/admin/ActiveMemberManage/Selector/SortSelector.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { MemberDetailInfo } from '@api/dto';
+import Selector from '@components/Selector/Selector';
+
+type SortInfo = {
+  generation: string;
+  realName: string;
+};
+
+interface SortSelectorProps {
+  memberList: MemberDetailInfo[];
+  setMemberList: React.Dispatch<React.SetStateAction<MemberDetailInfo[]>>;
+}
+
+const generationSearchList = [
+  {
+    id: '내림차순',
+    content: '내림차순',
+  },
+  {
+    id: '오름차순',
+    content: '오름차순',
+  },
+];
+const realNameSearchList = [
+  {
+    id: '가나다순',
+    content: '가나다순',
+  },
+  {
+    id: '역순',
+    content: '역순',
+  },
+];
+
+const SortSelector = ({ memberList, setMemberList }: SortSelectorProps) => {
+  const [sortInfo, setSortInfo] = useState<SortInfo>({
+    generation: '내림차순',
+    realName: '가나다순',
+  });
+
+  const sortMemberList = ({ generation, realName }: SortInfo) => {
+    const sortedList = [...memberList]
+      .sort((a, b) => {
+        const aRealName = a.realName;
+        const bRealName = b.realName;
+        return realName === '가나다순' ? aRealName.localeCompare(bRealName) : bRealName.localeCompare(aRealName);
+      })
+      .sort((a, b) => {
+        const aGeneration = parseFloat(a.generation);
+        const bGeneration = parseFloat(b.generation);
+        return generation === '내림차순' ? bGeneration - aGeneration : aGeneration - bGeneration;
+      });
+
+    setMemberList(sortedList);
+  };
+  return (
+    <div className="mb-5 flex space-x-2">
+      <Selector
+        className="w-32"
+        label="기수"
+        value={sortInfo.generation}
+        onChange={(e) => {
+          const generationSortInfo = e.target.value as string;
+          setSortInfo((prev) => ({ ...prev, generation: generationSortInfo }));
+          sortMemberList({ generation: generationSortInfo, realName: sortInfo.realName });
+        }}
+        options={generationSearchList}
+      />
+      <Selector
+        className="w-32"
+        label="이름"
+        value={sortInfo.realName}
+        onChange={(e) => {
+          const realNameSortInfo = e.target.value as string;
+          setSortInfo((prev) => ({ ...prev, realName: realNameSortInfo }));
+          sortMemberList({ generation: sortInfo.generation, realName: realNameSortInfo });
+        }}
+        options={realNameSearchList}
+      />
+    </div>
+  );
+};
+
+export default SortSelector;

--- a/src/pages/admin/ActiveMemberManage/Selector/SortSelector.tsx
+++ b/src/pages/admin/ActiveMemberManage/Selector/SortSelector.tsx
@@ -62,8 +62,8 @@ const SortSelector = ({ memberList, setMemberList }: SortSelectorProps) => {
         value={sortInfo.generation}
         onChange={(e) => {
           const generationSortInfo = e.target.value as string;
-          setSortInfo((prev) => ({ ...prev, generation: generationSortInfo }));
           sortMemberList({ generation: generationSortInfo, realName: sortInfo.realName });
+          setSortInfo((prev) => ({ ...prev, generation: generationSortInfo }));
         }}
         options={generationSearchList}
       />
@@ -73,8 +73,8 @@ const SortSelector = ({ memberList, setMemberList }: SortSelectorProps) => {
         value={sortInfo.realName}
         onChange={(e) => {
           const realNameSortInfo = e.target.value as string;
-          setSortInfo((prev) => ({ ...prev, realName: realNameSortInfo }));
           sortMemberList({ generation: sortInfo.generation, realName: realNameSortInfo });
+          setSortInfo((prev) => ({ ...prev, realName: realNameSortInfo }));
         }}
         options={realNameSearchList}
       />

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -5,6 +5,7 @@ import Library from '@pages/Library/Library';
 import Profile from '@pages/Profile/Profile';
 import SignUp from '@pages/SignUp/SignUp';
 import Study from '@pages/Study/Study';
+import ActiveMemberManage from '@pages/admin/ActiveMemberManage/ActiveMemberManage';
 import DutyManage from '@pages/admin/DutyManage/DutyManage';
 import LibraryManage from '@pages/admin/LibraryManage/LibraryManage';
 import MeritManage from '@pages/admin/MeritManage/MeritManage';
@@ -77,7 +78,7 @@ const useMainRouter = () =>
                 },
                 {
                   path: 'activeMemberManage',
-                  element: <div />,
+                  element: <ActiveMemberManage />,
                 },
                 {
                   path: 'meritManage',


### PR DESCRIPTION
## 연관 이슈
- #702
## 작업 요약
- 활동인원관리 페이지 구현했습니다
- 정렬 기능
- 인원 선택 (회원 카드 누를때 + 오토컴플리트에서 클릭할때 같이 적용되도록)
- 타입 변경 기능
-
- 타입변경 버튼누를때, "총 n명을 삭제하시겠습니까? 와 사람 리스트 띄워주는건 추후에.. 하겠습니다..

## 리뷰 요구사항
- 15분
- 파일나눌때 중복되는 props가 많아서 이걸 파일 여러개로 분리하는게 의미있을까하는데,, 더 좋은 방법 있으시면 말씀부탁드립니다.!

## Preview 이미지
<img width="891" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/b3bcf07b-b9b1-418c-a03c-3d09d18535c3">
<img width="874" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/87d1e0c3-d8ca-4af7-8d1d-c969034d378e">
