### PR TITLE
feat : 테이블 셀 선택 기능 확장

### DIFF
--- a/src/components/Table/StandardTable.interface.ts
+++ b/src/components/Table/StandardTable.interface.ts
@@ -7,6 +7,9 @@ export type Row<T> = T & {
   id: number;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Cell<T> = unknown; /* TODO 임시로 unknown 타입 사용 */
+
 export interface ChildComponent<T> {
   key: keyof T;
   value: T[keyof T];

--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Table, TableBody, TableCell, TableHead, TableRow, Typography 
 
 import StandardTablePagination from '@components/Pagination/StandardTablePagination';
 import { PaginationOption } from '@components/Pagination/StandardTablePagination.interface';
-import { ChildComponent, Column, Row } from './StandardTable.interface';
+import { Cell, ChildComponent, Column, Row } from './StandardTable.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface StandardTableProps<T extends Record<string, any>> {
@@ -12,6 +12,7 @@ interface StandardTableProps<T extends Record<string, any>> {
   fixedRows?: Row<T>[];
   rows: Row<T>[];
   onRowClick?: ({ rowData }: { rowData: Row<T> }) => void;
+  onCellClick?: ({ cellData }: { cellData: Cell<T> }) => void;
   childComponent?: ({ key, value, rowData }: ChildComponent<T>) => ReactNode;
   paginationOption?: PaginationOption;
 }
@@ -23,6 +24,7 @@ const StandardTable = <T extends Record<string, any>>({
   fixedRows,
   rows,
   onRowClick,
+  onCellClick,
   childComponent,
   paginationOption,
 }: StandardTableProps<T>) => {
@@ -65,8 +67,11 @@ const StandardTable = <T extends Record<string, any>>({
                     {columns.map((column) => {
                       return (
                         <TableCell
+                          onClick={onCellClick ? () => onCellClick({ cellData: row[column.key] }) : undefined}
                           padding={isCheckboxColumn(column.key) ? 'checkbox' : undefined}
-                          className="!border-subBlack bg-mainBlack !text-white"
+                          className={`${
+                            onCellClick && 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
+                          } !border-subBlack bg-mainBlack !text-white`}
                           key={column.key as string}
                         >
                           {isCheckboxColumn(column.key) ? (
@@ -96,8 +101,11 @@ const StandardTable = <T extends Record<string, any>>({
                   {columns.map((column) => {
                     return (
                       <TableCell
+                        onClick={onCellClick ? () => onCellClick({ cellData: row[column.key] }) : undefined}
                         padding={isCheckboxColumn(column.key) ? 'checkbox' : undefined}
-                        className="!border-subBlack bg-mainBlack !text-white"
+                        className={`${
+                          onCellClick && 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
+                        } !border-subBlack bg-mainBlack !text-white`}
                         key={column.key as string}
                       >
                         {isCheckboxColumn(column.key) ? (


### PR DESCRIPTION
## 연관 이슈
- Close #721
- #130 

## 작업 요약
- 테이블 셀 선택 가능하도록 확장하였습니다.

## 리뷰 요구사항
- 5분
- `Cell` 타입 바로 생각 안 나서 일단 `unknown`으로 했는데 혹시 타입 어떻게 지정하면 좋을 지 떠오르는 거 있으면 코멘트 부탁드립니다!

## Preview 예제코드
```tsx
...
  const onCellClick = ({ cellData }: { cellData: Cell<ExampleRowType> }) => {
    console.log(cellData);
  };

  return (
    <StandardTable<ExampleRowType>
      ...
      onCellClick={onCellClick}
      ...
    />
  );
...
```
