### PR TITLE
Feature/세미나 관리 세미나 cell 클릭 시 해당 출석 정보 다 받아오도록 처리 #723

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -229,18 +229,19 @@ export interface AttendResponseData {
   statusText: string;
 }
 
+export interface MemberSeminarAttendance {
+  attendanceId: number;
+  attendanceStatus: SeminarStatus;
+  excuse: string | null;
+  attendDate: string;
+}
+
 export interface AttendSeminarInfo {
   memberId: number;
   memberName: string;
   generation: number;
-  attendances: [
-    {
-      attendanceId: number;
-      attendanceStatus: SeminarStatus;
-      excuse: string | null;
-      attendDate: string;
-    },
-  ];
+  attendances: MemberSeminarAttendance[];
+  [key: `date${number}`]: MemberSeminarAttendance;
 }
 
 export interface AttendSeminarListInfo extends Page {

--- a/src/api/seminarApi.ts
+++ b/src/api/seminarApi.ts
@@ -100,7 +100,27 @@ const useEditAttendStatusMutation = (seminarId: number, memberId: number) => {
 const useGetAttendSeminarListMutation = ({ page, size }: { page?: number; size?: number }) => {
   const fetcher = () => axios.get(`/seminars/attendances`, { params: { page, size } }).then(({ data }) => data);
 
-  return useQuery<AttendSeminarListInfo>(seminarKeys.attendSeminarList, fetcher);
+  return useQuery<AttendSeminarListInfo>(seminarKeys.attendSeminarList, fetcher, {
+    select: (data) => {
+      const transformedContent = data.content.map((membersSeminarAttendInfo) => {
+        const seminarDateInfo = membersSeminarAttendInfo.attendances.reduce((prev, curr) => {
+          const seminarDate = curr.attendDate.replaceAll('-', '.') || '';
+
+          return { ...prev, [`date${seminarDate}`]: curr };
+        }, {});
+
+        return {
+          ...membersSeminarAttendInfo,
+          ...seminarDateInfo,
+        };
+      });
+
+      return {
+        ...data,
+        content: transformedContent,
+      };
+    },
+  });
 };
 
 const useAddSeminarMutation = () => {


### PR DESCRIPTION
## 연관 이슈
- Close #723

## 작업 요약
- 세미나 관리 세미나 cell 클릭 시 상태 변경에 사용되는 출석 정보 다 받아오도록 처리해주었습니다.

## 작업 상세 설명
- api 응답 변환 관련에서 코멘트 남겨 두겠습니다!

## 리뷰 요구사항
- ~선행 PR #722 먼저 리뷰 부탁드립니다!~ 머지 완료
- 현재 기수랑 이름도 셀 클릭이 되는데 해당 부분은 추후 클릭 안 되도록 처리 예정입니다!

## Preview 이미지
<img width="1470" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/cdda3762-4d61-42b0-ab52-1eada8d1b36a">
