### PR TITLE
feat : 프로필 탭별 url 적용

### DIFF
--- a/src/components/Tab/StandardTab.tsx
+++ b/src/components/Tab/StandardTab.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { Tab, Tabs } from '@mui/material';
 
 interface StandardTabProps {
-  options: { id: number; label: string }[];
+  options: { id: number; label: string; url?: string }[];
   tab: number;
   setTab: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -15,7 +16,14 @@ const StandardTab = ({ options, tab, setTab }: StandardTabProps) => {
   return (
     <Tabs value={tab} onChange={handleChange}>
       {options.map((option) => (
-        <Tab key={option.id} className="w-[120px] !text-base" label={option.label} />
+        <Tab
+          LinkComponent={NavLink}
+          component={NavLink}
+          key={option.id}
+          className="w-[120px] !text-base"
+          label={option.label}
+          to={option.url || ''}
+        />
       ))}
     </Tabs>
   );

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Navigate, useRoutes } from 'react-router-dom';
 import StandardTab from '@components/Tab/StandardTab';
 import ProfileSection from './Section/ProfileSection';
 import AttendanceTab from './Tab/AttendanceTab/AttendanceTab';
@@ -8,11 +9,20 @@ import PointTab from './Tab/PointTab/PointTab';
 
 const Profile = () => {
   const tabList = [
-    { id: 0, label: '출석부' },
-    { id: 1, label: '작성글' },
-    { id: 2, label: '도서' },
-    { id: 3, label: '포인트 내역' },
+    { id: 0, label: '출석부', url: 'attendance' },
+    { id: 1, label: '작성글', url: 'board' },
+    { id: 2, label: '도서', url: 'book' },
+    { id: 3, label: '포인트 내역', url: 'point' },
   ];
+
+  const panels = useRoutes([
+    { path: 'attendance', element: <AttendanceTab /> },
+    { path: 'board', element: <BoardTab /> },
+    { path: 'book', element: <BookTab /> },
+    { path: 'point', element: <PointTab /> },
+    { path: '*', element: <Navigate to="attendance" /> },
+  ]);
+
   const [tab, setTab] = useState(0);
 
   return (
@@ -22,12 +32,7 @@ const Profile = () => {
       </div>
       <div className="flex w-full max-w-container flex-col xl:h-full">
         <StandardTab options={tabList} tab={tab} setTab={setTab} />
-        <div className="mt-4 flex h-full border border-subGray p-4">
-          {tab === 0 && <AttendanceTab />}
-          {tab === 1 && <BoardTab />}
-          {tab === 2 && <BookTab />}
-          {tab === 3 && <PointTab />}
-        </div>
+        <div className="mt-4 flex h-full border border-subGray p-4">{panels}</div>
       </div>
     </div>
   );

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -48,7 +48,7 @@ const useMainRouter = () =>
               element: <SearchAccount />,
             },
             {
-              path: 'profile/:memberId',
+              path: 'profile/:memberId/*',
               element: <Profile />,
             },
           ],


### PR DESCRIPTION
## 연관 이슈
- Close #748

## 작업 요약
- 프로필 탭별로 url 적용했습니다!

## 리뷰 요구사항
- 7분
- 원래 hash로 처리하려고 했는데 기존에 적용되어 있는 searchParam과 탭과 url간 연동 등 처리하는 게 까다로워서 그냥 경로로 처리해주었습니다..! 혹시 다른 좋은 방법 있다면 제안해주세요!
- 새로고침 시 탭 패널 그대로인데 탭에 활성화된 탭 색은 default 값으로 돌아가서 해당 관련 처리 추가로 해줘야 할 것 같습니다!
  <img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/db104019-acf0-4402-b1c7-f664aa127a09">


## Preview 이미지
<img height="50" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/b9ba6755-ba2e-4636-b6b8-aa7287ff79c2">
<img height="50" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/755dd58b-37b5-4ff6-86d5-1860f5f08457">
<img height="50" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/36966d5a-e577-42b5-b128-4b25c8c09aab">
<img height="50" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/85f93a46-8b5e-4313-9268-43eebe25f7b7">
