### PR TITLE
Feature/비밀번호 찾기 인증 코드 관련 처리

### DIFF
--- a/src/api/SearchAccountApi.ts
+++ b/src/api/SearchAccountApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from 'react-query';
+import { useMutation } from 'react-query';
 import axios from 'axios';
 
 const useSearchIdMutation = () => {
@@ -14,12 +14,13 @@ const useRequestAuthCodeMutation = () => {
   return useMutation(fetcher);
 };
 
-const useCheckAuthCodeQuery = ({ loginId, email, authCode }: { loginId: string; email: string; authCode: string }) => {
-  const fetcher = () =>
+const useCheckAuthCodeMutation = () => {
+  const fetcher = ({ loginId, email, authCode }: { loginId: string; email: string; authCode: string }) =>
     axios.get('/sign-in/check-auth-code', { params: { loginId, email, authCode } }).then(({ data }) => data);
 
-  return useQuery(['checkAuthCode'], fetcher);
+  return useMutation(fetcher);
 };
+
 const useChangePasswordMutation = () => {
   const fetcher = ({
     email,
@@ -36,4 +37,4 @@ const useChangePasswordMutation = () => {
   return useMutation(fetcher);
 };
 
-export { useSearchIdMutation, useRequestAuthCodeMutation, useCheckAuthCodeQuery, useChangePasswordMutation };
+export { useSearchIdMutation, useRequestAuthCodeMutation, useCheckAuthCodeMutation, useChangePasswordMutation };

--- a/src/pages/login/Search/SearchPWFirstStep.tsx
+++ b/src/pages/login/Search/SearchPWFirstStep.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Divider, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';
 import { useCheckAuthCodeMutation, useRequestAuthCodeMutation } from '@api/SearchAccountApi';
+import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { validateEmail } from '@utils/validateEmail';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import EmailAuthInput from '@components/Input/EmailAuthInput';
@@ -32,6 +33,8 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
   const { mutate: checkAuth } = useCheckAuthCodeMutation();
 
   const [isSent, setIsSent] = useState(false);
+  const [idErrorMsg, setIdErrorMsg] = useState('');
+  const [emailErrorMsg, setEmailErrorMsg] = useState('');
   const [isValidEmail, setIsValidEmail] = useState(false);
   const [mailAuthenticationModalOpen, setMailAuthenticationModalOpen] = useState(false);
   const [matchInfoModalOpen, setMatchInfoModalOpen] = useState(false);
@@ -54,19 +57,27 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
 
   const handleRequestVerificationCode = () => {
     setIsSent(true);
-    if (form.id && form.email) {
-      requestAuthcode(
-        { loginId: form.id, email: form.email },
-        {
-          onSuccess: () => {
-            setMatchInfoModalOpen(false);
-          },
-          onError: () => {
-            setMatchInfoModalOpen(true);
-          },
-        },
-      );
+
+    if (!form.id) {
+      setIdErrorMsg(REQUIRE_ERROR_MSG);
+      return;
     }
+    if (!form.email) {
+      setEmailErrorMsg(REQUIRE_ERROR_MSG);
+      return;
+    }
+
+    requestAuthcode(
+      { loginId: form.id, email: form.email },
+      {
+        onSuccess: () => {
+          setMatchInfoModalOpen(false);
+        },
+        onError: () => {
+          setMatchInfoModalOpen(true);
+        },
+      },
+    );
   };
 
   const handleConfirmFirstStep = () => {
@@ -116,6 +127,8 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
             name="id"
             value={form.id}
             onChange={handleChange}
+            error={Boolean(idErrorMsg)}
+            helperText={idErrorMsg}
           />
         </div>
         <div className="flex flex-col gap-2 text-left sm:flex-row sm:items-center sm:justify-between">
@@ -129,6 +142,8 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
             onChange={handleChange}
             buttonDisabled={!isValidEmail || isSent}
             onAuthButtonClick={handleRequestVerificationCode}
+            error={Boolean(emailErrorMsg)}
+            helperText={emailErrorMsg}
           />
         </div>
         <WarningModal

--- a/src/pages/login/Search/SearchPWFirstStep.tsx
+++ b/src/pages/login/Search/SearchPWFirstStep.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Divider, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { DateTime } from 'luxon';
-import { useCheckAuthCodeQuery, useRequestAuthCodeMutation } from '@api/SearchAccountApi';
+import { useCheckAuthCodeMutation, useRequestAuthCodeMutation } from '@api/SearchAccountApi';
 import { validateEmail } from '@utils/validateEmail';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import EmailAuthInput from '@components/Input/EmailAuthInput';
@@ -29,11 +29,7 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
     isLoading: isEmailSendLoading,
     isSuccess: isEmailSendSuccess,
   } = useRequestAuthCodeMutation();
-  const { data: checkAuthcodeData } = useCheckAuthCodeQuery({
-    loginId: form.id,
-    email: form.email,
-    authCode: form.verificationCode,
-  });
+  const { mutate: checkAuth } = useCheckAuthCodeMutation();
 
   const [isSent, setIsSent] = useState(false);
   const [isValidEmail, setIsValidEmail] = useState(false);
@@ -74,11 +70,22 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
   };
 
   const handleConfirmFirstStep = () => {
-    if (checkAuthcodeData?.auth === true) {
-      setCurrentStep(2);
-    } else {
-      setIsValidAuthCode(false);
-    }
+    checkAuth(
+      {
+        loginId: form.id,
+        email: form.email,
+        authCode: form.verificationCode,
+      },
+      {
+        onSuccess: (data) => {
+          if (data?.auth === true) {
+            setCurrentStep(2);
+          } else {
+            setIsValidAuthCode(false);
+          }
+        },
+      },
+    );
   };
 
   const handleOtherEmailButtonClick = () => {

--- a/src/pages/login/Search/SearchPWFirstStep.tsx
+++ b/src/pages/login/Search/SearchPWFirstStep.tsx
@@ -32,6 +32,7 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
   } = useRequestAuthCodeMutation();
   const { mutate: checkAuth } = useCheckAuthCodeMutation();
 
+  const [expirationTime, setExpirationTime] = useState<DateTime | null>(null);
   const [isSent, setIsSent] = useState(false);
   const [idErrorMsg, setIdErrorMsg] = useState('');
   const [emailErrorMsg, setEmailErrorMsg] = useState('');
@@ -77,6 +78,7 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
       { loginId: form.id, email: form.email },
       {
         onSuccess: () => {
+          setExpirationTime(DateTime.now().plus({ seconds: TIMER_DURATION_SECOND }));
           setMatchInfoModalOpen(false);
         },
         onError: () => {
@@ -107,12 +109,20 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
 
   const handleOtherEmailButtonClick = () => {
     setIsSent(false);
+    setExpirationTime(null);
     setForm({ ...form, email: '', verificationCode: '' });
     setMailAuthenticationModalOpen(false);
   };
 
   const handleResendMailButtonClick = () => {
-    requestAuthcode({ loginId: form.id, email: form.email });
+    requestAuthcode(
+      { loginId: form.id, email: form.email },
+      {
+        onSuccess: () => {
+          setExpirationTime(DateTime.now().plus({ seconds: TIMER_DURATION_SECOND }));
+        },
+      },
+    );
     setMailAuthenticationModalOpen(false);
   };
 
@@ -169,7 +179,7 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
             value={form.verificationCode}
             onChange={handleChange}
             disabled={!(isSent && isEmailSendSuccess)}
-            expirationTime={DateTime.now().plus({ seconds: TIMER_DURATION_SECOND })}
+            expirationTime={expirationTime}
           />
         </div>
         {!isValidAuthCode && <p className="text-red-500">인증코드가 맞지 않습니다. 다시 입력해주세요.</p>}

--- a/src/pages/login/Search/SearchPWFirstStep.tsx
+++ b/src/pages/login/Search/SearchPWFirstStep.tsx
@@ -55,6 +55,12 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
     }
   };
 
+  const handleEmailBlur = () => {
+    if (!validateEmail(form.email)) {
+      setEmailErrorMsg('이메일 형식을 확인해주세요.');
+    }
+  };
+
   const handleRequestVerificationCode = () => {
     setIsSent(true);
 
@@ -140,6 +146,7 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
             isSuccess={isSent && isEmailSendSuccess}
             value={form.email}
             onChange={handleChange}
+            onBlur={handleEmailBlur}
             buttonDisabled={!isValidEmail || isSent}
             onAuthButtonClick={handleRequestVerificationCode}
             error={Boolean(emailErrorMsg)}

--- a/src/pages/login/Search/SearchPWFirstStep.tsx
+++ b/src/pages/login/Search/SearchPWFirstStep.tsx
@@ -173,22 +173,24 @@ const SearchPWFirstStep = ({ setCurrentStep, form, setForm }: SearchPWFirstStepP
           />
         </div>
         {!isValidAuthCode && <p className="text-red-500">인증코드가 맞지 않습니다. 다시 입력해주세요.</p>}
-        <div className="relative -mx-2 sm:-mx-20 ">
-          <Typography
-            variant={isMobile ? 'small' : 'paragraph'}
-            className="absolute right-0 w-fit hover:underline hover:underline-offset-4"
-            component="button"
-            onClick={() => setMailAuthenticationModalOpen(true)}
-          >
-            인증 메일이 오지 않았나요?
-          </Typography>
-          <MailAuthenticationModal
-            open={mailAuthenticationModalOpen}
-            onClose={() => setMailAuthenticationModalOpen(false)}
-            onOtherEmailButtonClick={handleOtherEmailButtonClick}
-            onResendMailButtonClick={handleResendMailButtonClick}
-          />
-        </div>
+        {isSent && (
+          <div className="relative -mx-2 sm:-mx-20 ">
+            <Typography
+              variant={isMobile ? 'small' : 'paragraph'}
+              className="absolute right-0 w-fit hover:underline hover:underline-offset-4"
+              component="button"
+              onClick={() => setMailAuthenticationModalOpen(true)}
+            >
+              인증 메일이 오지 않았나요?
+            </Typography>
+            <MailAuthenticationModal
+              open={mailAuthenticationModalOpen}
+              onClose={() => setMailAuthenticationModalOpen(false)}
+              onOtherEmailButtonClick={handleOtherEmailButtonClick}
+              onResendMailButtonClick={handleResendMailButtonClick}
+            />
+          </div>
+        )}
       </div>
       <Divider className="bg-pointBlue" />
       <div className="mt-10 text-center">

--- a/src/pages/login/Search/SearchPWSecondStep.tsx
+++ b/src/pages/login/Search/SearchPWSecondStep.tsx
@@ -22,10 +22,10 @@ const SearchPWSecondStep = ({ setCurrentStep, firstForm }: SearchPWSecondStepPro
     newPassword: '',
     confirmPassword: '',
   });
+  const [passwordErrorMsg, setPasswordErrorMsg] = useState('');
+  const [confirmPasswordErrorMsg, setConfirmPasswordErrorMsg] = useState('');
 
-  const isSamePassword = () => {
-    setIsSame(form.newPassword === form.confirmPassword);
-  };
+  const isSamePassword = form.newPassword === form.confirmPassword;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.currentTarget;
@@ -33,8 +33,24 @@ const SearchPWSecondStep = ({ setCurrentStep, firstForm }: SearchPWSecondStepPro
       ...form,
       [name]: value,
     });
+    if (name === 'newPassword') {
+      setPasswordErrorMsg('');
+    }
     if (name === 'confirmPassword') {
-      isSamePassword();
+      setIsSame(isSamePassword);
+      setConfirmPasswordErrorMsg('');
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement, Element>) => {
+    const { name, value } = e.currentTarget;
+    if (name === 'newPassword') {
+      if (value && !passwordRegex.test(value)) setPasswordErrorMsg('8~20자 영문과 숫자를 사용하세요.');
+    }
+    if (name === 'confirmPassword') {
+      if (!(value.length > 0 && isSame)) {
+        setConfirmPasswordErrorMsg('비밀번호가 일치하지 않습니다.');
+      }
     }
   };
 
@@ -57,7 +73,8 @@ const SearchPWSecondStep = ({ setCurrentStep, firstForm }: SearchPWSecondStepPro
   };
 
   useEffect(() => {
-    isSamePassword();
+    if (!isSame && form.confirmPassword.length <= 0) return;
+    setIsSame(isSamePassword);
   }, [form.newPassword, form.confirmPassword]);
 
   return (
@@ -78,10 +95,9 @@ const SearchPWSecondStep = ({ setCurrentStep, firstForm }: SearchPWSecondStepPro
             name="newPassword"
             value={form.newPassword}
             onChange={handleChange}
-            helperText={
-              form.newPassword &&
-              !passwordRegex.test(form.newPassword) && <p className="text-red-500">8~20자 영문과 숫자를 사용하세요.</p>
-            }
+            onBlur={handleBlur}
+            error={Boolean(passwordErrorMsg)}
+            helperText={passwordErrorMsg}
           />
         </div>
         <div className="flex flex-col gap-2 text-left sm:flex-row sm:items-center sm:justify-between">
@@ -94,13 +110,9 @@ const SearchPWSecondStep = ({ setCurrentStep, firstForm }: SearchPWSecondStepPro
             name="confirmPassword"
             value={form.confirmPassword}
             onChange={handleChange}
-            helperText={
-              form.confirmPassword !== '' && (
-                <p className={`${isSame ? 'text-pointBlue' : 'text-red-500'} text-left`}>
-                  {isSame ? '비밀번호가 일치합니다.' : '비밀번호가 일치하지 않습니다.'}
-                </p>
-              )
-            }
+            onBlur={handleBlur}
+            error={Boolean(confirmPasswordErrorMsg)}
+            helperText={confirmPasswordErrorMsg || (isSame && '비밀번호가 일치합니다.')}
           />
         </div>
       </div>


### PR DESCRIPTION
## 연관 이슈
- Close #627
- Close #761
- Close #762
- Close #774

## 작업 요약
- 비밀번호 찾기 인증 코드 관련 처리와 비밀번호 찾기 관련 에러 처리 작업해주었습니다.

## 작업 상세 설명
- 인증 코드 확인 api가 인증 버튼 클릭 후 확인해야 하는데 페이지 접근 시 바로 호출돼서 에러 발생하던 거 fix 해주었습니다.
- 비밀번호 찾기 인증코드 전송 시, 아이디와 이메일이 필요한데 아이디 입력하지 않은 지 아무런 안내 없이 인증이 안 되는 이슈가 있어서 이메일 인증코드 전송 시 아이디, 이메일 입력 필수 처리하고 입력값 없을 시 에러 문구 띄워주도록 처리하였습니다.
- 비밀번호 찾기 이메일 형식 안 맞을 때 버튼은 비활성화인데 안내문구가 없어서 blur 시 형식 맞추라는 에러 문구 표시해주었습니다.
- 인증 요청 전에는 `인증 메일 재전송`이나 `다른 이메일로 변경` 기능이 필요 없기 때문에 인증 요청 후에만 인증 메일 안내 문구 뜨도록 처리하였습니다.
- 인증 코드 타이머 설정을 컴포넌트 props로 바로 전달했어서 리렌더링 될 때마다 타이머 초기화되는 버그 fix 해주었습니다.
- 비밀번호 각 단계에서 에러 발생 후 수정이 안되는 문제 fix나 이벤트에 따른 문구 관련 처리 해주었습니다.

## 리뷰 요구사항
- 예상 소요 시간 15분
