### PR TITLE
Feature/상벌점페이지 정렬 필터링 #686

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -450,6 +450,7 @@ export interface MeritLogInfo {
   score: number;
   meritTypeId: number;
   reason: string;
+  isMerit: boolean;
 }
 
 export interface MeritLog {
@@ -470,6 +471,7 @@ export interface MeritTypeInfo {
   id: number;
   score: number;
   detail: string;
+  isMerit: boolean;
 }
 
 export interface MeritType {

--- a/src/api/meritApi.ts
+++ b/src/api/meritApi.ts
@@ -90,12 +90,34 @@ const useAddMeritTypeMutation = () => {
 const useEditMeritTypeMutation = () => {
   const queryClient = useQueryClient();
 
-  const fetcher = ({ score, reason, meritTypeId }: { score: number; reason: string; meritTypeId: number }) =>
-    axios.put(`/merits/types/${meritTypeId}`, { score, reason }).then(({ data }) => data);
+  const fetcher = ({
+    score,
+    reason,
+    meritTypeId,
+    isMerit,
+  }: {
+    score: number;
+    reason: string;
+    meritTypeId: number;
+    isMerit: boolean;
+  }) => axios.put(`/merits/types/${meritTypeId}`, { score, reason, isMerit }).then(({ data }) => data);
 
   return useMutation(fetcher, {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: meritKeys.meritType({ page: 0 }) });
+    },
+  });
+};
+
+const useDeleteMeritLogMutation = () => {
+  const queryClient = useQueryClient();
+
+  const fetcher = ({ meritLogId }: { meritLogId: number }) =>
+    axios.delete(`/merits/${meritLogId}`).then(({ data }) => data);
+
+  return useMutation(fetcher, {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: meritKeys.meritLog({ page: 0 }) });
     },
   });
 };
@@ -108,4 +130,5 @@ export {
   useAddMeritLogMutation,
   useAddMeritTypeMutation,
   useEditMeritTypeMutation,
+  useDeleteMeritLogMutation,
 };

--- a/src/api/meritApi.ts
+++ b/src/api/meritApi.ts
@@ -3,21 +3,21 @@ import axios from 'axios';
 import { PageAndSize, MeritLog, MeritType, MembersMerit } from './dto';
 
 const meritKeys = {
-  meritLog: (param: PageAndSize) => ['meritLog', param] as const,
+  meritLog: (param: PageAndSize & { meritType?: string }) => ['meritLog', param] as const,
   meritType: (param: PageAndSize) => ['meritType', param] as const,
   membersMerit: (param: PageAndSize) => ['membersMerit', param] as const,
   memberMerit: (param: PageAndSize & { memberId: number }) => ['memberMerit', param] as const,
 };
 
-const useGetMeritLogQuery = ({ page, size = 10 }: PageAndSize) => {
+const useGetMeritLogQuery = ({ page, size = 10, meritType = 'ALL' }: PageAndSize & { meritType?: string }) => {
   const fetcher = () =>
     axios
       .get('/merits', {
-        params: { page, size },
+        params: { page, size, meritType },
       })
       .then(({ data }) => data);
 
-  return useQuery<MeritLog>(meritKeys.meritLog({ page, size }), fetcher, {
+  return useQuery<MeritLog>(meritKeys.meritLog({ page, size, meritType }), fetcher, {
     keepPreviousData: true,
   });
 };

--- a/src/api/meritApi.ts
+++ b/src/api/meritApi.ts
@@ -77,8 +77,8 @@ const useAddMeritLogMutation = () => {
 const useAddMeritTypeMutation = () => {
   const queryClient = useQueryClient();
 
-  const fetcher = ({ score, reason }: { score: number; reason: string }) =>
-    axios.post(`/merits/types`, { score, reason }).then(({ data }) => data);
+  const fetcher = ({ score, reason, isMerit }: { score: number; reason: string; isMerit: boolean }) =>
+    axios.post(`/merits/types`, { score, reason, isMerit }).then(({ data }) => data);
 
   return useMutation(fetcher, {
     onSuccess: () => {

--- a/src/pages/admin/MeritManage/MeritManage.tsx
+++ b/src/pages/admin/MeritManage/MeritManage.tsx
@@ -23,12 +23,12 @@ const MeritManage = () => {
   const [tab, setTab] = useState(0);
 
   return (
-    <>
+    <div className="px-3">
       <StandardTab options={meritTabs} tab={tab} setTab={setTab} />
       {tab === 0 && <MeritLogTab />}
       {tab === 1 && <UserMeritTab />}
       {tab === 2 && <MeritTypeTab />}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/admin/MeritManage/Modal/DeleteMeritLogModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/DeleteMeritLogModal.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDeleteMeritLogMutation } from '@api/meritApi';
+import ActionModal from '@components/Modal/ActionModal';
+
+type DeleteMeritLogModalProps = {
+  open: boolean;
+  onClose: () => void;
+  meritLogId: number;
+};
+
+const DeleteMeritLogModal = ({ open, onClose, meritLogId }: DeleteMeritLogModalProps) => {
+  const { mutate: deleteMeritLog } = useDeleteMeritLogMutation();
+
+  return (
+    <ActionModal
+      open={open}
+      onClose={onClose}
+      title="상벌점 내역 삭제"
+      modalWidth="xs"
+      actionButtonName="삭제"
+      onActionButonClick={() => {
+        deleteMeritLog(
+          { meritLogId },
+          {
+            onSuccess: () => {
+              onClose();
+            },
+          },
+        );
+      }}
+    >
+      해당 상벌점 내역을 삭제하시겠습니까?
+    </ActionModal>
+  );
+};
+
+export default DeleteMeritLogModal;

--- a/src/pages/admin/MeritManage/Modal/DeleteMeritLogModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/DeleteMeritLogModal.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { useDeleteMeritLogMutation } from '@api/meritApi';
 import ActionModal from '@components/Modal/ActionModal';
 
-type DeleteMeritLogModalProps = {
+interface DeleteMeritLogModalProps {
   open: boolean;
   onClose: () => void;
   meritLogId: number;
-};
+}
 
 const DeleteMeritLogModal = ({ open, onClose, meritLogId }: DeleteMeritLogModalProps) => {
   const { mutate: deleteMeritLog } = useDeleteMeritLogMutation();

--- a/src/pages/admin/MeritManage/Modal/MemberMeritModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/MemberMeritModal.tsx
@@ -16,10 +16,10 @@ interface MeritLogRow {
 }
 
 const MeritLogColumn: Column<MeritLogRow>[] = [
-  { key: 'num', headerName: '번호' },
-  { key: 'giveTime', headerName: '일시' },
-  { key: 'score', headerName: '점수' },
-  { key: 'reason', headerName: '사유' },
+  { key: 'num', headerName: '번호', width: 100 },
+  { key: 'giveTime', headerName: '일시', width: 200 },
+  { key: 'score', headerName: '점수', width: 100 },
+  { key: 'reason', headerName: '사유', width: 300 },
 ];
 
 const MeritLogChildComponent = ({ key, value, rowData }: ChildComponent<MeritLogRow>) => {

--- a/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
@@ -126,9 +126,9 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
             onChange={(e) => {
               setMeritTypeInfo((prev) => ({ ...prev, score: Number(e.target.value) }));
             }}
-            options={Array.from(Array(10).keys()).map((i) => ({
-              id: i + 1,
-              content: i + 1,
+            options={Array.from(Array(21).keys()).map((i) => ({
+              id: i - 10,
+              content: i - 10,
             }))}
           />
         </div>

--- a/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
@@ -125,7 +125,7 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
             onChange={(e) => {
               setMeritTypeInfo((prev) => ({ ...prev, score: Number(e.target.value) }));
             }}
-            options={Array.from(Array(11).keys()).map((i) => ({
+            options={Array.from(Array(10).keys()).map((i) => ({
               id: i + 1,
               content: i + 1,
             }))}

--- a/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
@@ -6,20 +6,18 @@ import StandardInput from '@components/Input/StandardInput';
 import ActionModal from '@components/Modal/ActionModal';
 import Selector from '@components/Selector/Selector';
 
-type RewordOrPenalty = 'reword' | 'penalty';
-
 export type MeritTypeModalInfo = {
   id: number;
-  type: RewordOrPenalty;
   score: number;
   reason: string;
+  isMerit: boolean;
 };
 
 const baseMeritTypeInfo: MeritTypeModalInfo = {
   id: 0,
-  type: 'reword',
   score: 0,
   reason: '',
+  isMerit: true,
 };
 
 export const meritTypeChangeEnable = (meritTypeId: number) => {
@@ -81,6 +79,7 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
             meritTypeId: meritTypeInfo.id,
             score: meritTypeInfo.score,
             reason: meritTypeInfo.reason,
+            isMerit: meritTypeInfo.isMerit,
           },
           {
             onSuccess,
@@ -108,10 +107,10 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
     >
       <div className="grow space-y-5">
         <RadioButton
-          value={meritTypeInfo.type}
+          value={meritTypeInfo.isMerit ? 'reword' : 'penalty'}
           horizontal
           onChange={(e) => {
-            setMeritTypeInfo((prev) => ({ ...prev, type: e.target.value as RewordOrPenalty, score: 0 }));
+            setMeritTypeInfo((prev) => ({ ...prev, isMerit: e.target.value === 'reword' }));
           }}
           options={[
             { id: 'reword', content: '상점' },
@@ -127,8 +126,8 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
               setMeritTypeInfo((prev) => ({ ...prev, score: Number(e.target.value) }));
             }}
             options={Array.from(Array(11).keys()).map((i) => ({
-              id: (i + 1) * (meritTypeInfo.type === 'reword' ? 1 : -1),
-              content: (i + 1) * (meritTypeInfo.type === 'reword' ? 1 : -1),
+              id: i + 1,
+              content: i + 1,
             }))}
           />
         </div>

--- a/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
@@ -68,6 +68,7 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
           {
             score: meritTypeInfo.score,
             reason: meritTypeInfo.reason,
+            isMerit: meritTypeInfo.isMerit,
           },
           {
             onSuccess,

--- a/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
+++ b/src/pages/admin/MeritManage/Modal/SettingMeritTypeModal.tsx
@@ -6,6 +6,12 @@ import StandardInput from '@components/Input/StandardInput';
 import ActionModal from '@components/Modal/ActionModal';
 import Selector from '@components/Selector/Selector';
 
+// -10 ~ 10
+const SCORE_MIN = -10;
+const SCORE_RANGE = 21;
+
+const SCORE_LIST = Array.from({ length: SCORE_RANGE }, (_, i) => i + SCORE_MIN);
+
 export type MeritTypeModalInfo = {
   id: number;
   score: number;
@@ -126,9 +132,9 @@ const SettingMeritTypeModal = <Edit extends boolean | undefined = false>({
             onChange={(e) => {
               setMeritTypeInfo((prev) => ({ ...prev, score: Number(e.target.value) }));
             }}
-            options={Array.from(Array(21).keys()).map((i) => ({
-              id: i - 10,
-              content: i - 10,
+            options={SCORE_LIST.map((i) => ({
+              id: i,
+              content: i,
             }))}
           />
         </div>

--- a/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
@@ -21,11 +21,11 @@ interface MeritLogRow {
 }
 
 const MeritLogColumn: Column<MeritLogRow>[] = [
-  { key: 'index', headerName: '번호' },
-  { key: 'giveTime', headerName: '일시' },
-  { key: 'awarder', headerName: '이름 (기수)' },
-  { key: 'score', headerName: '점수' },
-  { key: 'reason', headerName: '사유' },
+  { key: 'index', headerName: '번호', width: 100 },
+  { key: 'giveTime', headerName: '일시', width: 200 },
+  { key: 'awarder', headerName: '이름 (기수)', width: 200 },
+  { key: 'score', headerName: '점수', width: 100 },
+  { key: 'reason', headerName: '사유', width: 300 },
 ];
 
 const MeritLogChildComponent = ({ key, value, rowData }: ChildComponent<MeritLogRow>) => {
@@ -60,7 +60,7 @@ const MeritLogTab = () => {
   };
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex flex-col">
       <div className="my-5 flex h-12 w-full justify-between">
         <Selector
           className="w-40"

--- a/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
@@ -8,17 +8,20 @@ import Selector from '@components/Selector/Selector';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 import AddMeritModal from '../Modal/AddMeritModal';
+import DeleteMeritLogModal from '../Modal/DeleteMeritLogModal';
 
 interface MeritLogRow {
   id: number;
+  index: number;
   giveTime: string;
   awarder: string;
   score: number;
   reason: string;
+  isMerit: boolean;
 }
 
 const MeritLogColumn: Column<MeritLogRow>[] = [
-  { key: 'id', headerName: '번호' },
+  { key: 'index', headerName: '번호' },
   { key: 'giveTime', headerName: '일시' },
   { key: 'awarder', headerName: '이름 (기수)' },
   { key: 'score', headerName: '점수' },
@@ -27,8 +30,8 @@ const MeritLogColumn: Column<MeritLogRow>[] = [
 
 const MeritLogChildComponent = ({ key, value, rowData }: ChildComponent<MeritLogRow>) => {
   let color = 'white';
-  if (rowData.score > 0) color = 'pointBlue';
-  else if (rowData.score < 0) color = 'subRed';
+  if (rowData.isMerit) color = 'pointBlue';
+  else if (!rowData.isMerit) color = 'subRed';
 
   switch (key) {
     case 'giveTime':
@@ -44,12 +47,17 @@ type ScoreType = 'MERIT' | 'DEMERIT' | 'ALL';
 
 const MeritLogTab = () => {
   const [addMeritOpen, setAddMeritOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState({ open: false, meritLogId: 0 });
   const [scoreType, setScoreType] = useState<ScoreType>('ALL');
-  const { page } = usePagination();
+  const { page, getRowNumber } = usePagination();
 
   const { data: meritLog } = useGetMeritLogQuery({ page, meritType: scoreType });
 
   if (!meritLog) return null;
+
+  const handleMeritLogClick = (meritLogId: number) => {
+    setDeleteModalOpen({ open: true, meritLogId });
+  };
 
   return (
     <div className="flex w-full flex-col">
@@ -73,14 +81,21 @@ const MeritLogTab = () => {
       </div>
       <StandardTable<MeritLogRow>
         columns={MeritLogColumn}
-        rows={meritLog.content.map((item) => ({
+        rows={meritLog.content.map((item, index) => ({
+          index: getRowNumber({ size: meritLog.size, index }),
           awarder: `${item.awarderName} (${parseFloat(item.awarderGeneration as string)}기)`,
           ...item,
         }))}
         childComponent={MeritLogChildComponent}
+        onRowClick={({ rowData }) => handleMeritLogClick(rowData.id)}
         paginationOption={{ rowsPerPage: meritLog.size, totalItems: meritLog.totalElements }}
       />
       <AddMeritModal open={addMeritOpen} onClose={() => setAddMeritOpen(false)} />
+      <DeleteMeritLogModal
+        open={deleteModalOpen.open}
+        onClose={() => setDeleteModalOpen({ open: false, meritLogId: 0 })}
+        meritLogId={deleteModalOpen.meritLogId}
+      />
     </div>
   );
 };

--- a/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritLogTab.tsx
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { useGetMeritLogQuery } from '@api/meritApi';
 import usePagination from '@hooks/usePagination';
 import ActionButton from '@components/Button/ActionButton';
+import Selector from '@components/Selector/Selector';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 import AddMeritModal from '../Modal/AddMeritModal';
@@ -39,17 +40,33 @@ const MeritLogChildComponent = ({ key, value, rowData }: ChildComponent<MeritLog
   }
 };
 
+type ScoreType = 'MERIT' | 'DEMERIT' | 'ALL';
+
 const MeritLogTab = () => {
   const [addMeritOpen, setAddMeritOpen] = useState(false);
+  const [scoreType, setScoreType] = useState<ScoreType>('ALL');
   const { page } = usePagination();
 
-  const { data: meritLog } = useGetMeritLogQuery({ page });
+  const { data: meritLog } = useGetMeritLogQuery({ page, meritType: scoreType });
 
   if (!meritLog) return null;
 
   return (
     <div className="flex w-full flex-col">
-      <div className="my-5 flex h-12 w-full justify-end">
+      <div className="my-5 flex h-12 w-full justify-between">
+        <Selector
+          className="w-40"
+          label="유형"
+          value={scoreType}
+          onChange={(e) => {
+            setScoreType(e.target.value as ScoreType);
+          }}
+          options={[
+            { id: 'ALL', content: '전체' },
+            { id: 'MERIT', content: '상점' },
+            { id: 'DEMERIT', content: '벌점' },
+          ]}
+        />
         <ActionButton mode="add" onClick={() => setAddMeritOpen(true)}>
           추가
         </ActionButton>

--- a/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
@@ -28,11 +28,11 @@ const MeritTypeChildComponent = ({ value, rowData }: ChildComponent<MeritTypeRow
   return <Typography className={`text-${color}`}>{value}</Typography>;
 };
 
-type ScoreType = 'reword' | 'penalty' | 'all';
+type ScoreType = 'MERIT' | 'DEMERIT' | 'ALL';
 
 const MeritTypeTab = () => {
   const { page } = usePagination();
-  const [scoreType, setScoreType] = useState<ScoreType>('all');
+  const [scoreType, setScoreType] = useState<ScoreType>('ALL');
 
   const [addMeritTypeOpen, setAddMeritTypeOpen] = useState(false);
   const [editMeritType, setEditMeritType] = useState<MeritTypeModalInfo | undefined>();
@@ -43,11 +43,11 @@ const MeritTypeTab = () => {
 
   const meritTypeFilter = (item: MeritTypeInfo) => {
     switch (scoreType) {
-      case 'reword':
+      case 'MERIT':
         return item.score > 0;
-      case 'penalty':
+      case 'DEMERIT':
         return item.score < 0;
-      case 'all':
+      case 'ALL':
         return true;
       default:
         return false;
@@ -65,9 +65,9 @@ const MeritTypeTab = () => {
             setScoreType(e.target.value as ScoreType);
           }}
           options={[
-            { id: 'all', content: '전체' },
-            { id: 'reword', content: '상점' },
-            { id: 'penalty', content: '벌점' },
+            { id: 'ALL', content: '전체' },
+            { id: 'MERIT', content: '상점' },
+            { id: 'DEMERIT', content: '벌점' },
           ]}
         />
         <ActionButton mode="add" onClick={() => setAddMeritTypeOpen(true)}>

--- a/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
 import { Typography } from '@mui/material';
-import { MeritTypeInfo } from '@api/dto';
 import { useGetMeritTypeQuery } from '@api/meritApi';
 import usePagination from '@hooks/usePagination';
 import ActionButton from '@components/Button/ActionButton';
-import Selector from '@components/Selector/Selector';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 import SettingMeritTypeModal, { MeritTypeModalInfo, meritTypeChangeEnable } from '../Modal/SettingMeritTypeModal';
@@ -13,6 +11,7 @@ interface MeritTypeRow {
   id: number;
   detail: string;
   score: number;
+  isMerit: boolean;
 }
 
 const MeritTypeColumn: Column<MeritTypeRow>[] = [
@@ -23,16 +22,13 @@ const MeritTypeColumn: Column<MeritTypeRow>[] = [
 
 const MeritTypeChildComponent = ({ value, rowData }: ChildComponent<MeritTypeRow>) => {
   let color = 'white';
-  if (rowData.score > 0) color = 'pointBlue';
-  else if (rowData.score < 0) color = 'subRed';
+  if (rowData.isMerit) color = 'pointBlue';
+  else if (!rowData.isMerit) color = 'subRed';
   return <Typography className={`text-${color}`}>{value}</Typography>;
 };
 
-type ScoreType = 'MERIT' | 'DEMERIT' | 'ALL';
-
 const MeritTypeTab = () => {
   const { page } = usePagination();
-  const [scoreType, setScoreType] = useState<ScoreType>('ALL');
 
   const [addMeritTypeOpen, setAddMeritTypeOpen] = useState(false);
   const [editMeritType, setEditMeritType] = useState<MeritTypeModalInfo | undefined>();
@@ -41,48 +37,22 @@ const MeritTypeTab = () => {
 
   if (!meritType) return null;
 
-  const meritTypeFilter = (item: MeritTypeInfo) => {
-    switch (scoreType) {
-      case 'MERIT':
-        return item.score > 0;
-      case 'DEMERIT':
-        return item.score < 0;
-      case 'ALL':
-        return true;
-      default:
-        return false;
-    }
-  };
-
   return (
     <div className="flex w-full flex-col">
-      <div className="my-5 flex h-12 w-full justify-between">
-        <Selector
-          className="w-40"
-          label="유형"
-          value={scoreType}
-          onChange={(e) => {
-            setScoreType(e.target.value as ScoreType);
-          }}
-          options={[
-            { id: 'ALL', content: '전체' },
-            { id: 'MERIT', content: '상점' },
-            { id: 'DEMERIT', content: '벌점' },
-          ]}
-        />
+      <div className="my-5 flex h-12 w-full justify-end">
         <ActionButton mode="add" onClick={() => setAddMeritTypeOpen(true)}>
           추가
         </ActionButton>
       </div>
       <StandardTable<MeritTypeRow>
         columns={MeritTypeColumn}
-        rows={meritType.content.filter(meritTypeFilter)}
+        rows={meritType.content}
         childComponent={MeritTypeChildComponent}
         onRowClick={({ rowData }) =>
           meritTypeChangeEnable(rowData.id) &&
           setEditMeritType({
             id: rowData.id,
-            type: rowData.score > 0 ? 'reword' : 'penalty',
+            isMerit: rowData.isMerit,
             score: rowData.score,
             reason: rowData.detail,
           })

--- a/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/MeritTypeTab.tsx
@@ -15,9 +15,9 @@ interface MeritTypeRow {
 }
 
 const MeritTypeColumn: Column<MeritTypeRow>[] = [
-  { key: 'id', headerName: '번호' },
-  { key: 'detail', headerName: '사유' },
-  { key: 'score', headerName: '점수' },
+  { key: 'id', headerName: '번호', width: 100 },
+  { key: 'detail', headerName: '사유', width: 300 },
+  { key: 'score', headerName: '점수', width: 100 },
 ];
 
 const MeritTypeChildComponent = ({ value, rowData }: ChildComponent<MeritTypeRow>) => {

--- a/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
@@ -31,7 +31,7 @@ const MembersMeritChildComponent = ({ key, value }: ChildComponent<MembersMeritR
     case 'merit':
       return <Typography className={`${(value as number) > 0 && 'text-pointBlue'}`}>{value}</Typography>;
     case 'demerit':
-      return <Typography className={`${(value as number) < 0 && 'text-subRed'}`}>{value}</Typography>;
+      return <Typography className={`${(value as number) > 0 && 'text-subRed'}`}>{value}</Typography>;
     default:
       return value;
   }

--- a/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
@@ -17,11 +17,11 @@ interface MembersMeritRow {
 }
 
 const MembersMeritColumn: Column<MembersMeritRow>[] = [
-  { key: 'id', headerName: '번호' },
-  { key: 'generation', headerName: '기수' },
-  { key: 'memberName', headerName: '이름' },
-  { key: 'merit', headerName: '상점' },
-  { key: 'demerit', headerName: '벌점' },
+  { key: 'id', headerName: '번호', width: 100 },
+  { key: 'generation', headerName: '기수', width: 200 },
+  { key: 'memberName', headerName: '이름', width: 200 },
+  { key: 'merit', headerName: '상점', width: 100 },
+  { key: 'demerit', headerName: '벌점', width: 100 },
 ];
 
 const MembersMeritChildComponent = ({ key, value }: ChildComponent<MembersMeritRow>) => {

--- a/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Typography } from '@mui/material';
 import { useGetMembersMeritQuery } from '@api/meritApi';
 import usePagination from '@hooks/usePagination';
-// import Selector from '@components/Selector/Selector';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 import MemberMeritModal, { MemberMeritModalState } from '../Modal/MemberMeritModal';
@@ -37,11 +36,8 @@ const MembersMeritChildComponent = ({ key, value }: ChildComponent<MembersMeritR
   }
 };
 
-// type SortType = 'highestReword' | 'highestPenalty';
-
 const UserMeritTab = () => {
   const { page, getRowNumber } = usePagination();
-  // const [sortType, setSortType] = useState<SortType>('highestReword');
   const [memberMeritOpen, setMemberMeritOpen] = useState<MemberMeritModalState>({
     memberId: 0,
     title: '',
@@ -52,21 +48,7 @@ const UserMeritTab = () => {
   if (!membersMerit) return null;
 
   return (
-    <div className="flex w-full flex-col">
-      <div className="my-5 flex h-12 w-full justify-between">
-        {/* <Selector
-          className="w-40"
-          label="정렬"
-          value={sortType}
-          onChange={(e) => {
-            setSortType(e.target.value as SortType);
-          }}
-          options={[
-            { id: 'highestReword', content: '상점 높은 순' },
-            { id: 'highestPenalty', content: '벌점 높은 순' },
-          ]}
-        /> */}
-      </div>
+    <div className="flex w-full flex-col pt-[5.5rem]">
       <StandardTable<MembersMeritRow>
         columns={MembersMeritColumn}
         rows={membersMerit.content.map((member, index) => ({

--- a/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
+++ b/src/pages/admin/MeritManage/Tab/UserMeritTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Typography } from '@mui/material';
 import { useGetMembersMeritQuery } from '@api/meritApi';
 import usePagination from '@hooks/usePagination';
-import Selector from '@components/Selector/Selector';
+// import Selector from '@components/Selector/Selector';
 import StandardTable from '@components/Table/StandardTable';
 import { ChildComponent, Column } from '@components/Table/StandardTable.interface';
 import MemberMeritModal, { MemberMeritModalState } from '../Modal/MemberMeritModal';
@@ -37,11 +37,11 @@ const MembersMeritChildComponent = ({ key, value }: ChildComponent<MembersMeritR
   }
 };
 
-type SortType = 'highestReword' | 'highestPenalty';
+// type SortType = 'highestReword' | 'highestPenalty';
 
 const UserMeritTab = () => {
   const { page, getRowNumber } = usePagination();
-  const [sortType, setSortType] = useState<SortType>('highestReword');
+  // const [sortType, setSortType] = useState<SortType>('highestReword');
   const [memberMeritOpen, setMemberMeritOpen] = useState<MemberMeritModalState>({
     memberId: 0,
     title: '',
@@ -54,7 +54,7 @@ const UserMeritTab = () => {
   return (
     <div className="flex w-full flex-col">
       <div className="my-5 flex h-12 w-full justify-between">
-        <Selector
+        {/* <Selector
           className="w-40"
           label="정렬"
           value={sortType}
@@ -65,7 +65,7 @@ const UserMeritTab = () => {
             { id: 'highestReword', content: '상점 높은 순' },
             { id: 'highestPenalty', content: '벌점 높은 순' },
           ]}
-        />
+        /> */}
       </div>
       <StandardTable<MembersMeritRow>
         columns={MembersMeritColumn}


### PR DESCRIPTION
## 연관 이슈
#686 

## 작업 요약
상벌점 페이지 api 변경사항 적용

## 작업 상세 설명
- isMerit로 상점 벌점 구분합니다
- 상점 벌점 음수가 추가됩니다 ( 상쇄용 )
- 반응형 처리 적용했습니다 (표 가로 스크롤)
- api가 없는 Selector 제거했습니다

## 리뷰 요구사항
10분
반응형 표 가로 스크롤로 적용하여 글씨가 새로로 길어지는 현상을 없게 했는데 괜찮을까요?
추가로 O기 OOO의 상벌점내역 글씨가 모바일에서는 넘어가기는 하는데 큰 문제 없어보여 별다른 처리는 안했습니다. 필요하면 처리하겠습니다.
API에 없는 정렬과 필터를 제외하여 개수가 많이 줄었습니다.
