### PR TITLE
Feature/세미나 관리 테이블 관련 처리 #786

### DIFF
--- a/src/components/Table/StandardTable.interface.ts
+++ b/src/components/Table/StandardTable.interface.ts
@@ -2,6 +2,7 @@ export interface Column<T> {
   key: keyof T | 'checkbox';
   headerName: string;
   width?: string | number;
+  fixed?: 'left' | 'right';
 }
 
 export type Row<T> = T & {

--- a/src/components/Table/StandardTable.tsx
+++ b/src/components/Table/StandardTable.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { Box, Checkbox, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 
+import { KEEPER_COLOR } from '@constants/keeperTheme';
 import StandardTablePagination from '@components/Pagination/StandardTablePagination';
 import { PaginationOption } from '@components/Pagination/StandardTablePagination.interface';
 import { Cell, ChildComponent, Column, Row } from './StandardTable.interface';
@@ -36,12 +37,17 @@ const StandardTable = <T extends Record<string, any>>({
         <Table size={size} sx={{ '.MuiTableCell-sizeSmall': { paddingY: '14px' } }}>
           <TableHead className="bg-middleBlack">
             <TableRow>
-              {columns.map((column) => (
+              {columns.map((column, index) => (
                 <TableCell
                   padding={isCheckboxColumn(column.key) ? 'checkbox' : undefined}
                   className="!truncate !border-subBlack !text-white"
                   width={column.width}
-                  sx={{ minWidth: column.width }}
+                  sx={{
+                    minWidth: column.width,
+                    position: column.fixed && 'sticky',
+                    left: column.fixed === 'left' ? index * 100 : undefined,
+                    backgroundColor: KEEPER_COLOR.middleBlack,
+                  }}
                   key={column.key as string}
                 >
                   {isCheckboxColumn(column.key) ? <Checkbox /> : column.headerName}
@@ -67,14 +73,25 @@ const StandardTable = <T extends Record<string, any>>({
                       key={row.id}
                       onClick={onRowClick ? () => onRowClick({ rowData: row }) : undefined}
                     >
-                      {columns.map((column) => {
+                      {columns.map((column, index) => {
                         return (
                           <TableCell
-                            onClick={onCellClick ? () => onCellClick({ cellData: row[column.key] }) : undefined}
+                            onClick={
+                              onCellClick && !column.fixed
+                                ? () => onCellClick({ cellData: row[column.key] })
+                                : undefined
+                            }
                             padding={isCheckboxColumn(column.key) ? 'checkbox' : undefined}
                             className={`${
-                              onCellClick && 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
+                              onCellClick &&
+                              !column.fixed &&
+                              'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
                             } !border-subBlack bg-mainBlack !text-white`}
+                            sx={{
+                              position: column.fixed && 'sticky',
+                              left: column.fixed === 'left' ? index * 100 : undefined,
+                              backgroundColor: column.fixed && KEEPER_COLOR.middleBlack,
+                            }}
                             key={column.key as string}
                           >
                             {isCheckboxColumn(column.key) ? (
@@ -101,14 +118,23 @@ const StandardTable = <T extends Record<string, any>>({
                     key={row.id}
                     onClick={onRowClick ? () => onRowClick({ rowData: row }) : undefined}
                   >
-                    {columns.map((column) => {
+                    {columns.map((column, index) => {
                       return (
                         <TableCell
-                          onClick={onCellClick ? () => onCellClick({ cellData: row[column.key] }) : undefined}
+                          onClick={
+                            onCellClick && !column.fixed ? () => onCellClick({ cellData: row[column.key] }) : undefined
+                          }
                           padding={isCheckboxColumn(column.key) ? 'checkbox' : undefined}
                           className={`${
-                            onCellClick && 'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
-                          } !border-subBlack bg-mainBlack !text-white`}
+                            onCellClick &&
+                            !column.fixed &&
+                            'hover:cursor-pointer hover:brightness-[.8] hover:drop-shadow-none'
+                          } overflow-hidden !border-subBlack bg-mainBlack !text-white`}
+                          sx={{
+                            position: column.fixed && 'sticky',
+                            left: column.fixed === 'left' ? index * 100 : undefined,
+                            backgroundColor: column.fixed && KEEPER_COLOR.middleBlack,
+                          }}
                           key={column.key as string}
                         >
                           {isCheckboxColumn(column.key) ? (

--- a/src/pages/admin/SeminarManage/SeminarManage.tsx
+++ b/src/pages/admin/SeminarManage/SeminarManage.tsx
@@ -13,8 +13,8 @@ import DeleteSeminarModal from './Modal/DeleteSeminarModal';
 import EditSeminarAttendanceModal from './Modal/EditSeminarAttendanceModal';
 
 const seminarManageColumn: Column<AttendSeminarInfo>[] = [
-  { key: 'generation', headerName: '기수' },
-  { key: 'memberName', headerName: '이름' },
+  { key: 'generation', headerName: '기수', fixed: 'left', width: 100 },
+  { key: 'memberName', headerName: '이름', fixed: 'left', width: 100 },
 ];
 
 const SeminarManage = () => {


### PR DESCRIPTION
## 연관 이슈
- #307, #786

## 작업 요약
- 테이블 column 좌측에 고정  가능하도록 처리하고 세미나 관리 테이블에 적용했습니다. (+고정된 column cell은 클릭 불가하도록 처리했습니다.)


## 리뷰 요구사항
- 10분
- 세미나 관리 테이블에 우측에 총 (출석, 지각, 결석, 개인사정) column도 고정해야하는데 API 나오면 우측 고정 기능도 추가 예정입니다!

## Preview 이미지

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/af9e8379-921d-4bd2-9d7b-9b528c47f98a

