### PR TITLE
Feature/세미나 출석 페이지 버그 픽스 #792

### DIFF
--- a/src/api/seminarApi.ts
+++ b/src/api/seminarApi.ts
@@ -48,9 +48,9 @@ const useGetAvailableSeminarInfoQuery = () => {
 };
 
 const useGetRecentlyDoneSeminarInfoQuery = () => {
-  const fetcher = () => axios.get(`/seminars/recently-done`).then(({ data }) => data.id);
+  const fetcher = () => axios.get(`/seminars/recently-done`).then(({ data }) => data);
 
-  return useQuery<number>(seminarKeys.getRecentlyDoneSeminar, fetcher);
+  return useQuery<{ id: number }>(seminarKeys.getRecentlyDoneSeminar, fetcher);
 };
 
 const useGetRecentlyUpcomingSeminarInfoQuery = () => {

--- a/src/api/seminarApi.ts
+++ b/src/api/seminarApi.ts
@@ -5,7 +5,7 @@ import { AttendSeminarListInfo, SeminarStatus, SeminarInfo } from './dto';
 
 const seminarKeys = {
   getSeminarList: ['getSeminar', 'seminarList'] as const,
-  getSeminar: ['getSeminar', 'id'] as const,
+  getSeminar: ({ id }: { id: number }) => ['getSeminar', id] as const,
   getAvailableSeminar: ['getSeminar', 'available'] as const,
   getRecentlyDoneSeminar: ['getSeminar', 'recentlyDone'] as const,
   getRecentlyUpcomingSeminar: ['getSeminar', 'recentlyUpcoming'] as const,
@@ -38,7 +38,7 @@ const useGetSeminarInfoQuery = (id: number) => {
       return transformedData;
     });
 
-  return useQuery<SeminarInfo>(seminarKeys.getSeminar, fetcher);
+  return useQuery<SeminarInfo>(seminarKeys.getSeminar({ id }), fetcher);
 };
 
 const useGetAvailableSeminarInfoQuery = () => {


### PR DESCRIPTION
## 연관 이슈
- #792

## 작업 상세 설명
- 배열 map 돌릴 때 key 중복값있어서 오류 발생하는 거 해결했습니다.
- 두 api에서 받아온 데이터를 한 배열로 다루는데, 두 데이터를 다 받아왔을 때 배열 set해주도록 변경했습니다.
- 동일한 queryKey로 서로 다른 세미나인데도 같은 캐싱된 값이 뜨는 버그 해결했습니다.

## 리뷰 요구사항
- 예상 소요 시간 10분
- 현재 db 변경사항 대기중이라 나머지 버그는 db 변경 후 처리 예정입니다!
