### PR TITLE
Feature/게시글 조회 페이지 버그 픽스 #789

### DIFF
--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -180,10 +180,17 @@ const useGetEachPostQuery = (
   });
 };
 
-const useGetPostFilesQuery = (postId: number, fileOpen: boolean) => {
+const useGetPostFilesQuery = (postId: number, fileOpen: boolean, password?: string) => {
+  const queryClient = useQueryClient();
+
   const fetcher = () => axios.get(`/posts/${postId}/files`).then(({ data }) => data);
 
-  return useQuery<FileInfo[]>(['files', postId], fetcher, { enabled: fileOpen });
+  return useQuery<FileInfo[]>(['files', postId], fetcher, {
+    enabled: fileOpen,
+    onSuccess: () => {
+      queryClient.setQueryData(['post', postId, password], (oldData) => oldData && { ...oldData, isRead: true });
+    },
+  });
 };
 
 const useGetRecentPostsQuery = () => {

--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -139,7 +139,12 @@ const useDeleteFilesMutation = () => {
   return useMutation(fetcher);
 };
 
-const useGetEachPostQuery = (postId: number, isSecret: boolean | null, password?: string) => {
+const useGetEachPostQuery = (
+  postId: number,
+  isSecret: boolean | null,
+  setIsSecretPasswordSubmited: boolean,
+  password?: string,
+) => {
   const location = useLocation();
 
   const { handleError } = useApiError({
@@ -162,7 +167,7 @@ const useGetEachPostQuery = (postId: number, isSecret: boolean | null, password?
   const fetcher = () => axios.get(`/posts/${postId}`, { params: { password } }).then(({ data }) => data);
 
   return useQuery<PostInfo>(['post', postId, password], fetcher, {
-    enabled: !isSecret || Boolean(isSecret && password),
+    enabled: !isSecret || Boolean(isSecret && setIsSecretPasswordSubmited),
     onError: (err) => {
       if ((err as AxiosError)?.response?.status === 403) {
         if (isSecret === null) {

--- a/src/components/Modal/ActionModal.tsx
+++ b/src/components/Modal/ActionModal.tsx
@@ -14,6 +14,7 @@ interface ActionModalProps {
   actionButtonDisabled?: boolean;
   actionButtonName: string;
   onActionButonClick: () => void;
+  onActionEnterKeyUp?: () => void;
 }
 
 const ActionModal = ({
@@ -27,13 +28,23 @@ const ActionModal = ({
   actionButtonDisabled = false,
   actionButtonName,
   onActionButonClick,
+  onActionEnterKeyUp,
 }: ActionModalProps) => {
+  const onKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!onActionEnterKeyUp) return;
+
+    if (e.key === 'Enter') {
+      onActionEnterKeyUp();
+    }
+  };
+
   return (
     <Dialog
       open={open}
       PaperProps={{ className: '!bg-subBlack brightness-125 !bg-none px-2 py-1' }}
       fullWidth={Boolean(modalWidth)}
       maxWidth={modalWidth}
+      onKeyUp={onKeyUp}
     >
       <DialogTitle className="flex items-center gap-x-2 !font-bold text-pointBlue">
         {startAdornment}

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -41,6 +41,12 @@ const BoardView = () => {
     setSecretPostModalOpen(true);
   }, [isSecret]);
 
+  useEffect(() => {
+    return () => {
+      setPassword(undefined);
+    };
+  }, [postId]);
+
   if (error) {
     if ((error as AxiosError)?.response?.status === 404) {
       return <NotFound from="Post" />;

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -19,13 +19,19 @@ const BoardView = () => {
   } = useLocation();
 
   const [secretPostModalOpen, setSecretPostModalOpen] = useState(false);
+  const [isSecretPasswordSubmited, setIsSecretPasswordSubmited] = useState(false);
   const [password, setPassword] = useState<string>();
 
-  const { data: postInfo, isSuccess, error } = useGetEachPostQuery(postId, isSecret, password);
+  const {
+    data: postInfo,
+    isSuccess,
+    error,
+  } = useGetEachPostQuery(postId, isSecret, isSecretPasswordSubmited, password);
 
   useEffect(() => {
-    if (!isSuccess) return;
+    setIsSecretPasswordSubmited(false);
 
+    if (!isSuccess) return;
     setSecretPostModalOpen(false);
   }, [isSuccess]);
 
@@ -53,7 +59,12 @@ const BoardView = () => {
           <CommentSection categoryName={postInfo.categoryName} postId={postId} allowComment={postInfo.allowComment} />
         </>
       )}
-      <SecretPostModal setPassword={setPassword} open={secretPostModalOpen} setOpen={setSecretPostModalOpen} />
+      <SecretPostModal
+        setPassword={setPassword}
+        setIsSecretPasswordSubmited={setIsSecretPasswordSubmited}
+        open={secretPostModalOpen}
+        setOpen={setSecretPostModalOpen}
+      />
     </div>
   );
 };

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -53,7 +53,7 @@ const BoardView = () => {
         <>
           <div className="space-y-2">
             <BannerSection postId={postId} post={postInfo} />
-            <PostSection postId={postId} post={postInfo} />
+            <PostSection postId={postId} post={postInfo} password={password} />
           </div>
           <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />
           <CommentSection categoryName={postInfo.categoryName} postId={postId} allowComment={postInfo.allowComment} />

--- a/src/pages/board/BoardView/Modal/SecretPostModal.tsx
+++ b/src/pages/board/BoardView/Modal/SecretPostModal.tsx
@@ -17,10 +17,11 @@ interface SecretPostModalProps {
 const SecretPostModal = ({ setPassword, setIsSecretPasswordSubmited, open, setOpen }: SecretPostModalProps) => {
   const navigate = useNavigate();
 
-  const { control, getValues } = useForm({ mode: 'onBlur' });
+  const { control, getValues, reset } = useForm({ mode: 'onBlur' });
 
   const handlePasswordConfirmClick = () => {
     setPassword(getValues('password'));
+    reset();
     setIsSecretPasswordSubmited(true);
   };
 

--- a/src/pages/board/BoardView/Modal/SecretPostModal.tsx
+++ b/src/pages/board/BoardView/Modal/SecretPostModal.tsx
@@ -24,6 +24,10 @@ const SecretPostModal = ({ setPassword, setIsSecretPasswordSubmited, open, setOp
     setIsSecretPasswordSubmited(true);
   };
 
+  const handleActionEnterKeyUp = () => {
+    handlePasswordConfirmClick();
+  };
+
   return (
     <ActionModal
       open={open}
@@ -34,6 +38,7 @@ const SecretPostModal = ({ setPassword, setIsSecretPasswordSubmited, open, setOp
       title="비밀글 보기"
       actionButtonName="확인"
       onActionButonClick={handlePasswordConfirmClick}
+      onActionEnterKeyUp={handleActionEnterKeyUp}
     >
       <Typography>비밀글을 보려면 비밀번호를 입력해주세요.</Typography>
       <Typography variant="small">(작성자는 확인 버튼만 누르면 됩니다.)</Typography>

--- a/src/pages/board/BoardView/Modal/SecretPostModal.tsx
+++ b/src/pages/board/BoardView/Modal/SecretPostModal.tsx
@@ -9,21 +9,19 @@ import ActionModal from '@components/Modal/ActionModal';
 
 interface SecretPostModalProps {
   setPassword: Dispatch<SetStateAction<string | undefined>>;
+  setIsSecretPasswordSubmited: Dispatch<SetStateAction<boolean>>;
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const SecretPostModal = ({ setPassword, open, setOpen }: SecretPostModalProps) => {
+const SecretPostModal = ({ setPassword, setIsSecretPasswordSubmited, open, setOpen }: SecretPostModalProps) => {
   const navigate = useNavigate();
 
-  const {
-    control,
-    getValues,
-    formState: { isValid },
-  } = useForm({ mode: 'onBlur' });
+  const { control, getValues } = useForm({ mode: 'onBlur' });
 
-  const handlePasswordConfirmClick = async () => {
+  const handlePasswordConfirmClick = () => {
     setPassword(getValues('password'));
+    setIsSecretPasswordSubmited(true);
   };
 
   return (
@@ -35,7 +33,6 @@ const SecretPostModal = ({ setPassword, open, setOpen }: SecretPostModalProps) =
       }}
       title="비밀글 보기"
       actionButtonName="확인"
-      actionButtonDisabled={!isValid}
       onActionButonClick={handlePasswordConfirmClick}
     >
       <Typography>비밀글을 보려면 비밀번호를 입력해주세요.</Typography>
@@ -46,7 +43,7 @@ const SecretPostModal = ({ setPassword, open, setOpen }: SecretPostModalProps) =
           defaultValue=""
           control={control}
           rules={{
-            required: REQUIRE_ERROR_MSG,
+            required: `작성자가 아닐 시 ${REQUIRE_ERROR_MSG}`,
             maxLength: {
               value: POST_PASSWORD_MAX_LENGTH,
               message: `비밀번호는 최대 ${POST_PASSWORD_MAX_LENGTH}글자 입력이 가능합니다.`,

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -17,14 +17,15 @@ import WarningDeductPointModal from '../Modal/WarningDeductPointModal';
 interface PostSectionProps {
   postId: number;
   post: PostInfo;
+  password?: string;
 }
 
-const PostSection = ({ postId, post }: PostSectionProps) => {
+const PostSection = ({ postId, post, password }: PostSectionProps) => {
   const [fileOpen, toggleFileOpen] = useReducer((prev) => !prev, false);
   const [warningModalOpen, setWarningModalOpen] = useState(false);
   const hasWarningModal = post.categoryName === '시험게시판' && post.isRead === false && !fileOpen;
 
-  const { data: files } = useGetPostFilesQuery(postId, fileOpen);
+  const { data: files } = useGetPostFilesQuery(postId, fileOpen, password);
   const { mutate: controlLikes } = useControlPostLikesMutation();
   const { mutate: controlDislikes } = useControlPostDislikesMutation();
   const { mutate: downloadFile } = useDownloadFileMutation();


### PR DESCRIPTION
## 연관 이슈
- #789

## 작업 상세
-  작성자는 비밀번호 입력 안하고 확인 버튼만 눌러도 비밀글 조회 가능해야 하는데, 비밀번호 필수값 처리로 버튼 비활성화 처리해뒀어서 확인 버튼만으로 조회 불가능한 버그가 있어서 별도의 비활성화 넣지 않도록 처리했습니다.
-  api의 `isRead`로 주의 모달이 뜰 지 여부를 제어하는데 시험 게시판 첨부파일 바로 닫았다 열때 api가 동기화 되지 않은 상태가서 한 번 조회한 이후에도 모달이 뜨는 버그가 있어서 한 번 조회시 isRead값 캐싱데이터에서 변경해주어 처리해주었습니다.
-  비밀글 비밀번호 기입 엔터 가능하도록 처리했습니다.
-  비밀글 나간 후 password reset되도록 하여 다른 게시글로 갔다가 다시 접속 시 비밀글의 캐싱데이터로 비밀번호 입력 전에 게시글이 보이게 되는 버그 픽스했습니다.

## 리뷰 요구사항
- 10분
