### PR TITLE
fix : 직책관리 페이지 버그 픽스

### DIFF
--- a/src/mocks/DutyManageApi.ts
+++ b/src/mocks/DutyManageApi.ts
@@ -16,142 +16,67 @@ const roleDutyListInfo: RoleDutyList[] = [
   {
     jobName: 'ROLE_회장',
     roleDuty: [
-      { key: 1, content: '회장역할 1' },
-      { key: 2, content: '회장역할 2' },
-      { key: 3, content: '회장역할 3' },
-      { key: 4, content: '회장역할 4' },
-      { key: 5, content: '회장역할 5' },
-      { key: 6, content: '회장역할 6' },
+      {
+        key: 1,
+        content: '회장은 본회를 대표하며, 본회에서 주최하는 모든 행사의 대표자와 사회자를 맡으며, 인사관리를 담당한다.',
+      },
+      { key: 2, content: '대표자나 사회자의 역할은 필요에 따라 대리인에게 위임할 수 있다.' },
     ],
   },
   {
     jobName: 'ROLE_부회장',
     roleDuty: [
-      { key: 1, content: '부회장역할 1' },
-      { key: 2, content: '부회장역할 2' },
-      { key: 3, content: '부회장역할 3' },
-      { key: 4, content: '부회장역할 4' },
-      { key: 5, content: '부회장역할 5' },
-      {
-        key: 6,
-        content:
-          '굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 긴 문자열',
-      },
+      { key: 1, content: '부회장은 회장의 업무를 보좌하며, 회장의 부재 시 우선적으로 회장의 역할을 위임받는다.' },
     ],
   },
   {
     jobName: 'ROLE_학술부장',
-    roleDuty: [
-      { key: 1, content: '학술부장역할 1' },
-      { key: 2, content: '학술부장역할 2' },
-      { key: 3, content: '학술부장역할 3' },
-      { key: 4, content: '학술부장역할 4' },
-      { key: 5, content: '학술부장역할 5' },
-      {
-        key: 6,
-        content:
-          '굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 긴 문자열',
-      },
-    ],
+    roleDuty: [{ key: 1, content: '학술부장은 본회의 모든 연구 활동, 스터디, 각종 문서, 강의실 대여를 관리한다.' }],
   },
   {
     jobName: 'ROLE_대외부장',
-    roleDuty: [
-      { key: 1, content: '대외부장역할 1' },
-      { key: 2, content: '대외부장역할 2' },
-      { key: 3, content: '대외부장역할 3' },
-      { key: 4, content: '대외부장역할 4' },
-      { key: 5, content: '대외부장역할 5' },
-      { key: 6, content: '대외부장역할 6' },
-    ],
+    roleDuty: [{ key: 1, content: '동아리 지원사업 관리 및 유지하며 관련 자료를 수집, 기록한다.' }],
   },
   {
     jobName: 'ROLE_전산관리자',
     roleDuty: [
-      { key: 1, content: '전산관리자역할 1' },
-      { key: 2, content: '전산관리자역할 2' },
-      { key: 3, content: '전산관리자역할 3' },
-      { key: 4, content: '전산관리자역할 4' },
-      { key: 5, content: '전산관리자역할 5' },
-      { key: 6, content: '전산관리자역할 6' },
+      { key: 1, content: '전산 관리자는 본회의 서버, 홈페이지를 비롯한 모든 전산 작업의 유지 및 보수를 담당한다.' },
     ],
   },
   {
     jobName: 'ROLE_서기',
     roleDuty: [
-      { key: 1, content: '서기역할 1' },
-      { key: 2, content: '서기역할 2' },
-      { key: 3, content: '서기역할 3' },
-      { key: 4, content: '서기역할 4' },
-      { key: 5, content: '서기역할 5' },
-      { key: 6, content: '서기역할 6' },
+      {
+        key: 1,
+        content: '서기는 본회에서 일어나는 모든 활동 및 행사의 기록, 보관 및 도서 관련 업무를 담당한다.',
+      },
+      { key: 2, content: '상점과 처벌에 의한 벌점을 관리한다.' },
     ],
   },
   {
     jobName: 'ROLE_사서',
-    roleDuty: [
-      { key: 1, content: '사서역할 1' },
-      { key: 2, content: '사서역할 2' },
-      { key: 3, content: '사서역할 3' },
-      { key: 4, content: '사서역할 4' },
-      {
-        key: 5,
-        content:
-          '굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 긴 문자열',
-      },
-      { key: 6, content: '사서역할 6' },
-    ],
+    roleDuty: [{ key: 1, content: '사서는 동아리에 새로 들어오는 책에 표시(주기)하고, 동아리 소유의 책을 관리한다.' }],
   },
   {
     jobName: 'ROLE_총무',
-    roleDuty: [
-      { key: 1, content: '총무역할 1' },
-      { key: 2, content: '총무역할 2' },
-      {
-        key: 3,
-        content:
-          '굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 긴 문자열',
-      },
-      { key: 4, content: '총무역할 4' },
-      { key: 5, content: '총무역할 5' },
-      { key: 6, content: '총무역할 6' },
-    ],
+    roleDuty: [{ key: 1, content: '총무는 본회의 재무를 담당하며, 본회에서 주최하는 모든 재정적 업무를 총괄한다.' }],
   },
   {
     jobName: 'ROLE_FRONT_전산관리자',
     roleDuty: [
-      { key: 1, content: 'FRONT 1' },
-      { key: 2, content: 'FRONT 2' },
-      { key: 3, content: 'FRONT 3' },
-      { key: 4, content: 'FRONT 4' },
-      { key: 5, content: 'FRONT 5' },
-      { key: 6, content: 'FRONT 6' },
+      { key: 1, content: '전산 관리자는 본회의 서버, 홈페이지를 비롯한 모든 전산 작업의 유지 및 보수를 담당한다.' },
     ],
   },
   {
     jobName: 'ROLE_BACK_전산관리자',
     roleDuty: [
-      { key: 1, content: 'BACK 1' },
-      {
-        key: 2,
-        content:
-          '굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 굉장히 긴 문자열',
-      },
-      { key: 3, content: 'BACK 3' },
-      { key: 4, content: 'BACK 4' },
-      { key: 5, content: 'BACK 5' },
-      { key: 6, content: 'BACK 6' },
+      { key: 1, content: '전산 관리자는 본회의 서버, 홈페이지를 비롯한 모든 전산 작업의 유지 및 보수를 담당한다.' },
     ],
   },
   {
     jobName: 'ROLE_INFRA_전산관리자',
     roleDuty: [
-      { key: 1, content: 'INFRA 1' },
-      { key: 2, content: 'INFRA 2' },
-      { key: 3, content: 'INFRA 3' },
-      { key: 4, content: 'INFRA 4' },
-      { key: 5, content: 'INFRA 5' },
-      { key: 6, content: 'INFRA 6' },
+      { key: 1, content: '전산 관리자는 본회의 서버, 홈페이지를 비롯한 모든 전산 작업의 유지 및 보수를 담당한다.' },
     ],
   },
 ];
@@ -167,4 +92,23 @@ const roles = [
   { name: 'ROLE_사서', img: librarianBadge },
 ];
 
-export { roleDutyListInfo, roles };
+export type JobInfoType = {
+  JobName: string;
+  roleName: string;
+};
+
+const convertJobName: Array<JobInfoType> = [
+  { JobName: 'ROLE_회장', roleName: '회장' },
+  { JobName: 'ROLE_부회장', roleName: '부회장' },
+  { JobName: 'ROLE_대외부장', roleName: '대외부장' },
+  { JobName: 'ROLE_학술부장', roleName: '학술부장' },
+  { JobName: 'ROLE_FRONT_전산관리자', roleName: 'FRONT' },
+  { JobName: 'ROLE_BACK_전산관리자', roleName: 'BACK' },
+  { JobName: 'ROLE_서기', roleName: '서기' },
+  { JobName: 'ROLE_총무', roleName: '총무' },
+  { JobName: 'ROLE_사서', roleName: '사서' },
+  { JobName: 'ROLE_INFRA_전산관리자', roleName: 'INFRA' },
+  { JobName: 'ROLE_전산관리자', roleName: '전산관리자' },
+];
+
+export { roleDutyListInfo, roles, convertJobName };

--- a/src/pages/admin/DutyManage/Button/DutyProfileButton.tsx
+++ b/src/pages/admin/DutyManage/Button/DutyProfileButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Typography } from '@mui/material';
 import { useGetExecutiveInfoQuery } from '@api/dutyManageApi';
 import muiTheme from '@constants/muiTheme';
+import { convertJobName } from '@mocks/DutyManageApi';
 
 interface DutyProfileButtonProps {
   jobName?: string;
@@ -9,20 +10,6 @@ interface DutyProfileButtonProps {
   setTooltipOpen: (open: boolean) => void;
   toggleModalOpen: () => void;
 }
-
-const convertJobName = [
-  { key: 1, JobName: 'ROLE_회장', roleName: '회장' },
-  { key: 2, JobName: 'ROLE_부회장', roleName: '부회장' },
-  { key: 3, JobName: 'ROLE_대외부장', roleName: '대외부장' },
-  { key: 4, JobName: 'ROLE_학술부장', roleName: '학술부장' },
-  { key: 5, JobName: 'ROLE_FRONT_전산관리자', roleName: 'FRONT' },
-  { key: 6, JobName: 'ROLE_BACK_전산관리자', roleName: 'BACK' },
-  { key: 7, JobName: 'ROLE_서기', roleName: '서기' },
-  { key: 8, JobName: 'ROLE_총무', roleName: '총무' },
-  { key: 9, JobName: 'ROLE_사서', roleName: '사서' },
-  { key: 12, JobName: 'ROLE_INFRA_전산관리자', roleName: 'INFRA' },
-  { key: 99, JobName: 'ROLE_전산관리자', roleName: '전산관리자' },
-];
 
 const DutyProfileButton = ({ jobName, badgeImage, setTooltipOpen, toggleModalOpen }: DutyProfileButtonProps) => {
   const { data: executiveInfos } = useGetExecutiveInfoQuery();

--- a/src/pages/admin/DutyManage/DutyManage.tsx
+++ b/src/pages/admin/DutyManage/DutyManage.tsx
@@ -65,7 +65,7 @@ const ViceChairman = () => {
             <div className="absolute bottom-1/2 right-1/2 h-4 w-4 translate-x-1/2 translate-y-1/2 rounded-full bg-pointBlue" />
           </div>
         </div>
-        <div className="absolute left-[40%]">
+        <div className="absolute left-[40%] translate-y-2">
           <DutyProfileTooltip jobName="ROLE_부회장" />
         </div>
       </div>

--- a/src/pages/admin/DutyManage/Tooltip/DutyProfileTooltip.tsx
+++ b/src/pages/admin/DutyManage/Tooltip/DutyProfileTooltip.tsx
@@ -2,6 +2,7 @@ import React, { useState, useReducer, useMemo } from 'react';
 import { Typography } from '@mui/material';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import { VscSearch } from 'react-icons/vsc';
 import muiTheme from '@constants/muiTheme';
 import { roleDutyListInfo, roles } from '@mocks/DutyManageApi';
 
@@ -57,28 +58,26 @@ const DutyProfileTooltip = ({ jobName }: DutyProfileTooltipProps) => {
   }
 
   return (
-    <DescriptionRoleDutyTooltip
-      title={jobName !== 'ROLE_전산관리자' ? tooltipContent(jobName) : null}
-      open={tooltipOpen}
-      onMouseEnter={() => setTooltipOpen(true)}
-      onMouseLeave={() => setTooltipOpen(false)}
-      arrow
-    >
-      <div>
-        <DutyProfileButton
-          jobName={jobName}
-          badgeImage={badgeImage}
-          setTooltipOpen={setTooltipOpen}
-          toggleModalOpen={toggleModalOpen}
-        />
-        <ChangeRolePersonModal
-          open={modalOpen}
-          toggleOpen={toggleModalOpen}
-          jobName={jobName}
-          badgeImage={badgeImage}
-        />
-      </div>
-    </DescriptionRoleDutyTooltip>
+    <div className="relative">
+      <DutyProfileButton
+        jobName={jobName}
+        badgeImage={badgeImage}
+        setTooltipOpen={setTooltipOpen}
+        toggleModalOpen={toggleModalOpen}
+      />
+      <DescriptionRoleDutyTooltip
+        title={jobName !== 'ROLE_전산관리자' ? tooltipContent(jobName) : null}
+        open={tooltipOpen}
+        onMouseEnter={() => setTooltipOpen(true)}
+        onMouseLeave={() => setTooltipOpen(false)}
+        arrow
+      >
+        <div className="absolute -right-2 top-0.5 rounded-full border border-white p-1">
+          <VscSearch size={12} className="w-full" />
+        </div>
+      </DescriptionRoleDutyTooltip>
+      <ChangeRolePersonModal open={modalOpen} toggleOpen={toggleModalOpen} jobName={jobName} badgeImage={badgeImage} />
+    </div>
   );
 };
 


### PR DESCRIPTION
## 연관 이슈
- #798 

## 작업 요약
- 직책 변경시 다른 직책이 변경되는 오류 수정
- 사람 선택하지 않고 직책 변경 시 해당 직책 제거
- 직책에 관련된 업무 설명 글 수정
- 직책 변경시 업무 설명 글이 떠서 변경하기 힘든 이슈 해결

## 리뷰 요구사항
- `5분`
