### PR TITLE
Feature/세미나 출석 페이지 버그 픽스 #792

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -237,16 +237,24 @@ export interface SignUpDuplication {
   duplicate: boolean;
 }
 
-export interface SeminarInfo {
+export interface SeminarCoreInfo {
   id: number;
   name: string;
   openTime: DateTime;
-  attendanceCloseTime: DateTime;
-  latenessCloseTime: DateTime;
-  attendanceCode: string;
+  attendanceCloseTime: DateTime | null;
+  latenessCloseTime: DateTime | null;
+  statusType: SeminarStatus;
+  attendanceCode: string | null;
+}
+
+export interface SeminarCardInfo extends SeminarCoreInfo {
+  attendanceStartTime: DateTime | null;
+  starterId: number | null;
+}
+
+export interface SeminarInfo extends SeminarCoreInfo {
   registerTime: DateTime;
   updateTime: DateTime;
-  statusType: SeminarStatus;
 }
 
 export interface AttendResponseData {

--- a/src/api/seminarApi.ts
+++ b/src/api/seminarApi.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import axios from 'axios';
 import { DateTime } from 'luxon';
-import { AttendSeminarListInfo, SeminarStatus, SeminarInfo } from './dto';
+import { AttendSeminarListInfo, SeminarStatus, SeminarInfo, SeminarCardInfo } from './dto';
 
 const seminarKeys = {
   getSeminarList: ['getSeminar', 'seminarList'] as const,
@@ -31,14 +31,15 @@ const useGetSeminarInfoQuery = (id: number) => {
       const transformedData = {
         ...data,
         name: data.name.replaceAll('-', '.'),
-        openTime: DateTime.fromISO(data.openTime),
-        attendanceCloseTime: DateTime.fromISO(data.attendanceCloseTime),
-        latenessCloseTime: DateTime.fromISO(data.latenessCloseTime),
+        openTime: data.openTime ? DateTime.fromISO(data.openTime) : null,
+        attendanceStartTime: data.attendanceStartTime ? DateTime.fromISO(data.attendanceStartTime) : null,
+        attendanceCloseTime: data.attendanceCloseTime ? DateTime.fromISO(data.attendanceCloseTime) : null,
+        latenessCloseTime: data.latenessCloseTime ? DateTime.fromISO(data.latenessCloseTime) : null,
       };
       return transformedData;
     });
 
-  return useQuery<SeminarInfo>(seminarKeys.getSeminar({ id }), fetcher);
+  return useQuery<SeminarCardInfo>(seminarKeys.getSeminar({ id }), fetcher);
 };
 
 const useGetAvailableSeminarInfoQuery = () => {

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -22,9 +22,11 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
   const { mutate: setSeminarTime } = useStartSeminarMutation(seminarId);
   const { data: availableSeminarData } = useGetAvailableSeminarInfoQuery();
   const member: MemberInfo | null = useRecoilValue(memberState);
+  const now = DateTime.now();
 
   const handleOnStartSeminar = () => {
     setStartTime(DateTime.now());
+    setSeminarStart(true);
     setStartMember(member?.memberId);
     setSeminarTime({
       attendanceCloseTime: startTime.plus({ minutes: attendValue }).toFormat('yyyy-MM-dd HH:mm:ss'),
@@ -56,7 +58,7 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
           <div>지각</div>
         </div>
         <div className="grid content-between text-right">
-          {seminarData && !seminarData.attendanceStartTime ? (
+          {!seminarStart && seminarData && !seminarData.attendanceStartTime ? (
             <>
               <SeminarSelector limitValue={attendValue} setLimitValue={setAttendValue} />
               <SeminarSelector limitValue={lateAttendValue} setLimitValue={setLateAttendValue} />
@@ -73,7 +75,7 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
         </div>
       </div>
       <div className="mt-[39px] flex justify-center">
-        {seminarData && !seminarData.attendanceStartTime ? (
+        {!seminarStart && seminarData && !seminarData.attendanceStartTime ? (
           <FilledButton onClick={handleOnStartSeminar}>시작</FilledButton>
         ) : (
           seminarData && <SeminarAttendStatus status={seminarData?.statusType} />

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -56,24 +56,27 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
           <div>지각</div>
         </div>
         <div className="grid content-between text-right">
-          {seminarStart && seminarData ? (
-            <>
-              <Countdown startTime={seminarData.openTime} endTime={seminarData.attendanceCloseTime} />
-              <Countdown startTime={seminarData.attendanceCloseTime} endTime={seminarData.latenessCloseTime} />
-            </>
-          ) : (
+          {seminarData && !seminarData.attendanceStartTime ? (
             <>
               <SeminarSelector limitValue={attendValue} setLimitValue={setAttendValue} />
               <SeminarSelector limitValue={lateAttendValue} setLimitValue={setLateAttendValue} />
+            </>
+          ) : (
+            <>
+              <Countdown startTime={seminarData?.openTime ?? null} endTime={seminarData?.attendanceCloseTime ?? null} />
+              <Countdown
+                startTime={seminarData?.attendanceCloseTime ?? null}
+                endTime={seminarData?.latenessCloseTime ?? null}
+              />
             </>
           )}
         </div>
       </div>
       <div className="mt-[39px] flex justify-center">
-        {seminarStart ? (
-          <SeminarAttendStatus status="ATTENDANCE" />
-        ) : (
+        {seminarData && !seminarData.attendanceStartTime ? (
           <FilledButton onClick={handleOnStartSeminar}>시작</FilledButton>
+        ) : (
+          seminarData && <SeminarAttendStatus status={seminarData?.statusType} />
         )}
       </div>
     </>

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -44,7 +44,7 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
         disabled
         helperText="ㅤ"
         setInputCode={() => null}
-        inputCode={seminarStart && seminarData ? seminarData?.attendanceCode : ''}
+        inputCode={seminarStart && seminarData && seminarData?.attendanceCode ? seminarData?.attendanceCode : ''}
       />
       <div className="mx-auto mt-[20px] flex h-[60px] w-[146px] justify-between">
         <div className="grid content-between">

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -33,8 +33,12 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
   };
 
   useEffect(() => {
-    if (seminarData && availableSeminarData?.id === seminarData.id) setSeminarStart(true);
-  }, [availableSeminarData]);
+    if (!seminarData || !availableSeminarData) return;
+
+    if (availableSeminarData.id === seminarData.id) {
+      setSeminarStart(true);
+    }
+  }, [seminarData, availableSeminarData]);
 
   return (
     <>

--- a/src/pages/senimarAttend/Card/MemberCardContent.tsx
+++ b/src/pages/senimarAttend/Card/MemberCardContent.tsx
@@ -97,7 +97,7 @@ const MemberCardContent = ({ seminarId }: { seminarId: number }) => {
         <div className="grid content-between text-right">
           {seminarData && (
             <>
-              <Countdown startTime={seminarData.openTime} endTime={seminarData.attendanceCloseTime} />
+              <Countdown startTime={seminarData.attendanceStartTime} endTime={seminarData.attendanceCloseTime} />
               <Countdown startTime={seminarData.attendanceCloseTime} endTime={seminarData.latenessCloseTime} />
             </>
           )}

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -1,33 +1,31 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 
-import { DateTime, Duration } from 'luxon';
+import { DateTime } from 'luxon';
+import TextTimer from '@components/Typography/TextTimer';
 
 interface countdownProps {
-  startTime: DateTime;
-  endTime: DateTime;
+  startTime: DateTime | null;
+  endTime: DateTime | null;
 }
 
 const Countdown = ({ startTime, endTime }: countdownProps) => {
-  const [nowTime, setNowTime] = useState(DateTime.now());
-  const id = useRef<NodeJS.Timeout>();
-  const [timeDiff, setTimeDiff] = useState<Duration>(endTime.diff(startTime));
-  const [leftTime, setLeftTime] = useState('');
+  const renderCountdownText = () => {
+    const now = DateTime.now();
 
-  const changeNowTime = () => {
-    setNowTime(DateTime.now());
+    if (!startTime || !endTime) {
+      return '--:--';
+    }
+    if (now < startTime) {
+      return endTime.diff(startTime).toFormat('mm:ss');
+    }
+    if (now > endTime) {
+      return '마감';
+    }
+
+    return <TextTimer expirationTime={endTime} />;
   };
 
-  useEffect(() => {
-    setTimeDiff(endTime.diff(nowTime));
-    id.current = setInterval(changeNowTime, 1000);
-    return () => clearInterval(id.current);
-  }, [nowTime]);
-
-  useEffect(() => {
-    if (id.current) setLeftTime(endTime > nowTime ? timeDiff.toFormat('mm:ss') : '마감');
-  }, [timeDiff]);
-
-  return <p className="text-white">{startTime > nowTime ? endTime.diff(startTime).toFormat('mm:ss') : leftTime}</p>;
+  return <div>{renderCountdownText()}</div>;
 };
 
 export default Countdown;


### PR DESCRIPTION
## 연관 이슈

- #792 

## 작업 상세 설명

 타이머 관련 버그 픽스
 - 타이머 출석 시작 시간 세미나 생성 시간 -> 세미나 시작 시간으로 변경
 - 세미나 시작 전 표기(`--:--`) 기획에 맞춰 추가
 - 타이머 동작하지 않을 때 리렌더링 되지 않도록 처리
 출석 카드 관련 버그 픽스
 - 관리자일 때 세미나 진행 중 새로고침 시 세미나 시작 전 카드 뜨는 버그 픽스
 - 끝난 세미나인데 출석 시작전의 카드가 보이는 버그 픽스
