### PR TITLE
Feature/avartar 서버 프로필 공통 컴포넌트 #800

### DIFF
--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -429,6 +429,7 @@ export interface TodayAttendRank {
 }
 
 export interface PointRankInfo {
+  thumbnailPath?: string | null;
   realName: string;
   generation: string;
   point: number;

--- a/src/api/dto.ts
+++ b/src/api/dto.ts
@@ -453,7 +453,7 @@ export interface GameRankInfo {
   realName: string;
   generation: string;
   todayEarnedPoint: number;
-  profileImageUrl?: string | null;
+  thumbnailPath?: string | null;
   memberId: number;
 }
 

--- a/src/components/Avatar/ServerAvatar.tsx
+++ b/src/components/Avatar/ServerAvatar.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Avatar } from '@mui/material';
+import { getServerImgUrl } from '@utils/converter';
+
+interface ServerAvatarProps {
+  className?: string;
+  thumbnailPath?: string | null;
+}
+
+const ServerAvatar = ({ className, thumbnailPath }: ServerAvatarProps) => {
+  return <Avatar className={className} src={thumbnailPath ? getServerImgUrl(thumbnailPath) : ''} />;
+};
+
+export default ServerAvatar;

--- a/src/components/Card/PostingCard.tsx
+++ b/src/components/Card/PostingCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Avatar, Card, CardContent, CardMedia, Stack, Typography } from '@mui/material';
+import { Card, CardContent, CardMedia, Stack, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
 import { AiFillLock } from 'react-icons/ai';
 import { VscComment, VscEye, VscThumbsup } from 'react-icons/vsc';
 import { ReactComponent as Logo } from '@assets/logo/logo_neon.svg';
 import { getServerImgUrl } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import { Row } from '@components/Table/StandardTable.interface';
 import { CardDetailInfoProps, CardMainInfoProps, InteractionScoreProps } from './PostingCard.interface';
 
@@ -30,7 +31,7 @@ export const CardMainInfo = ({ registerTime }: CardMainInfoProps) => {
 export const CardDetailInfo = ({ writerThumbnailPath, writerName, registerTime }: CardDetailInfoProps) => {
   return (
     <div className="flex">
-      <Avatar className="mr-2 !h-6 !w-6" src={writerThumbnailPath ?? undefined} />
+      <ServerAvatar className="mr-2 !h-6 !w-6" thumbnailPath={writerThumbnailPath} />
       <Stack>
         <Typography className="font-medium" variant="small">
           {writerName}

--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -49,6 +49,7 @@ const muiTheme = createTheme({
       styleOverrides: {
         root: {
           backgroundColor: KEEPER_COLOR.subBlack,
+          filter: 'brightness(.85)',
           color: KEEPER_COLOR.subGray,
         },
         fallback: {

--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -49,6 +49,7 @@ const muiTheme = createTheme({
       styleOverrides: {
         root: {
           backgroundColor: KEEPER_COLOR.subBlack,
+          color: KEEPER_COLOR.subGray,
         },
         fallback: {
           fill: 'white',

--- a/src/constants/muiTheme.ts
+++ b/src/constants/muiTheme.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@mui/material/styles';
+import { KEEPER_COLOR } from './keeperTheme';
 
 const muiTheme = createTheme({
   palette: {
@@ -41,6 +42,16 @@ const muiTheme = createTheme({
             colorScheme: 'dark',
             WebkitBackgroundClip: 'text !important',
           },
+        },
+      },
+    },
+    MuiAvatar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: KEEPER_COLOR.subBlack,
+        },
+        fallback: {
+          fill: 'white',
         },
       },
     },

--- a/src/pages/Profile/Section/FollowList.tsx
+++ b/src/pages/Profile/Section/FollowList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { List, ListItemIcon, ListItem, ListItemButton, Avatar, Typography } from '@mui/material';
+import { List, ListItemIcon, ListItem, ListItemButton, Typography } from '@mui/material';
 import { FollowInfo } from '@api/dto';
-import { getServerImgUrl } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 
 interface FollowListProps {
   followlist: FollowInfo[];
@@ -23,10 +23,7 @@ const FollowList = ({ followlist }: FollowListProps) => {
             }}
           >
             <ListItemIcon className="items-center">
-              <Avatar
-                className="m-1 !h-5 !w-5 !bg-subBlack !text-white sm:!h-8 sm:!w-8"
-                src={followInfo?.thumbnailPath ? getServerImgUrl(followInfo?.thumbnailPath) : ''}
-              />
+              <ServerAvatar className="m-1 !h-5 !w-5 sm:!h-8 sm:!w-8" thumbnailPath={followInfo?.thumbnailPath} />
               <Typography className="!text-small sm:!text-paragraph">
                 {followInfo.generation}기 {followInfo.name}
               </Typography>

--- a/src/pages/Profile/Section/ProfileSection.tsx
+++ b/src/pages/Profile/Section/ProfileSection.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Avatar, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Typography, useMediaQuery, useTheme } from '@mui/material';
 import { FollowInfo } from '@api/dto';
 import { useGetProfileQuery, useFollowMemberMutation, useUnFollowMemberMutation } from '@api/memberApi';
 import useCheckAuth from '@hooks/useCheckAuth';
-import { getServerImgUrl } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import TextButton from '@components/Button/TextButton';
 import BadgeSection from './BadgeSection';
@@ -54,10 +54,7 @@ const ProfileSection = () => {
   return (
     <div className="flex w-full space-x-6 space-y-0 p-4 xl:flex-col xl:space-x-0 xl:space-y-4">
       <div className="flex w-1/2 flex-col items-center space-y-2  xl:w-full">
-        <Avatar
-          className="!h-40 !w-40 !bg-subBlack !text-white lg:!h-60 lg:!w-60"
-          src={profileInfo?.thumbnailPath ? getServerImgUrl(profileInfo?.thumbnailPath) : ''}
-        />
+        <ServerAvatar className="!h-40 !w-40 lg:!h-60 lg:!w-60" thumbnailPath={profileInfo?.thumbnailPath} />
         <div className="flex w-full justify-between  ">
           <Typography variant={`${isMobile ? 'h3' : 'h1'}`} className="!font-semibold">
             {profileInfo?.realName}

--- a/src/pages/admin/ActiveMemberManage/Card/MemberCard.tsx
+++ b/src/pages/admin/ActiveMemberManage/Card/MemberCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Typography, Avatar } from '@mui/material';
+import { Typography } from '@mui/material';
 import { MemberDetailInfo } from '@api/dto';
-import { getServerImgUrl } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 
 interface MemberCardProps {
   memberInfo: MemberDetailInfo;
@@ -23,10 +23,7 @@ const MemberCard = ({ memberInfo, onClick, isSelected }: MemberCardProps) => {
       } flex h-fit items-center border border-transparent bg-middleBlack/50 p-1
       `}
     >
-      <Avatar
-        className="mr-1 !h-7 !w-7 !bg-subBlack !text-white "
-        src={memberInfo?.thumbnailPath ? getServerImgUrl(memberInfo?.thumbnailPath) : ''}
-      />
+      <ServerAvatar className="mr-1 !h-7 !w-7" thumbnailPath={memberInfo?.thumbnailPath} />
       <Typography className="!text-[14px]">{memberInfo.realName}</Typography>
       <Typography variant="small" className="!ml-1">
         ({memberInfo.generation})

--- a/src/pages/board/BoardView/Card/CommentCardFooter.tsx
+++ b/src/pages/board/BoardView/Card/CommentCardFooter.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Avatar, CardActions, Typography } from '@mui/material';
+import { CardActions, Typography } from '@mui/material';
+import { useRecoilValue } from 'recoil';
 import { useCreateCommentMutation } from '@api/commentApi';
 import { CommentInfo } from '@api/dto';
+import memberState from '@recoil/member.recoil';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import CommentWriteCardAction from './CommentWriteCardAction';
 
 interface CommentCardFooterProps {
@@ -15,6 +18,8 @@ const CommentCardFooter = ({ commentInfo }: CommentCardFooterProps) => {
 
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyContent, setReplyContent] = useState('');
+
+  const member = useRecoilValue(memberState);
   const { mutate: createReply } = useCreateCommentMutation();
 
   const handleReplyClick = () => {
@@ -41,8 +46,7 @@ const CommentCardFooter = ({ commentInfo }: CommentCardFooterProps) => {
         />
       ) : (
         <div className="flex w-full items-center justify-between gap-2">
-          {/* TODO 현재 계정 프로필 썸네일 가져오기 */}
-          <Avatar className="!h-7 !w-7" alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />
+          <ServerAvatar className="!h-7 !w-7" thumbnailPath={member?.thumbnailPath} />
           <button
             type="button"
             className="flex h-9 w-full items-center border border-subBlack bg-mainBlack pl-3"

--- a/src/pages/board/BoardView/Card/CommentCardHeader.tsx
+++ b/src/pages/board/BoardView/Card/CommentCardHeader.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Avatar, Button, CardHeader, useMediaQuery, useTheme } from '@mui/material';
+import { Button, CardHeader, useMediaQuery, useTheme } from '@mui/material';
 import { MdThumbDown, MdThumbUp } from 'react-icons/md';
 import { VscTrash } from 'react-icons/vsc';
 import { useControlCommentLikesMutation, useControlCommentDislikesMutation } from '@api/commentApi';
 import { CommentInfo } from '@api/dto';
 import useCheckAuth from '@hooks/useCheckAuth';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import CommentMenu from '../Menu/CommentMenu';
 
 interface CommentCardHeaderProps {
@@ -30,7 +31,7 @@ const CommentCardHeader = ({ commentInfo }: CommentCardHeaderProps) => {
 
   return !commentInfo.isDeleted ? (
     <CardHeader
-      avatar={<Avatar className="!h-7 !w-7" alt="프로필 이미지" src={commentInfo.writerThumbnailPath ?? undefined} />}
+      avatar={<ServerAvatar className="!h-7 !w-7" thumbnailPath={commentInfo.writerThumbnailPath} />}
       action={
         <div className="mr-1 space-x-2">
           <Button

--- a/src/pages/board/BoardView/Section/BannerSection.tsx
+++ b/src/pages/board/BoardView/Section/BannerSection.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Avatar, Chip, Typography } from '@mui/material';
+import { Chip, Typography } from '@mui/material';
 import { VscCalendar, VscEye } from 'react-icons/vsc';
 import { PostInfo } from '@api/dto';
 import { useDeletePostMutation } from '@api/postApi';
 import useCheckAuth from '@hooks/useCheckAuth';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import ServerImg from '@components/Image/ServerImg';
 import ActionModal from '@components/Modal/ActionModal';
@@ -47,7 +48,7 @@ const BannerSection = ({ postId, post }: BannerSectionProps) => {
           </Typography>
           <div className="flex items-center justify-center gap-2 text-small leading-8 text-gray-300">
             <div className="flex items-center justify-center">
-              <Avatar className="mr-1 !h-4 !w-4" src={post.writerThumbnailPath ?? undefined} />
+              <ServerAvatar className="mr-1 !h-4 !w-4" thumbnailPath={post.writerThumbnailPath} />
               {post.writerName}
             </div>
             <div className="flex items-center justify-center">

--- a/src/pages/home/Trendings.tsx
+++ b/src/pages/home/Trendings.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Avatar, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { DateTime } from 'luxon';
 import { TrendingPostInfo } from '@api/dto';
 import { useGetRecentPostsQuery, useGetTrendPostsQuery } from '@api/postApi';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import ServerImg from '@components/Image/ServerImg';
 
 const Card = ({ post }: { post: TrendingPostInfo }) => {
@@ -21,7 +22,7 @@ const Card = ({ post }: { post: TrendingPostInfo }) => {
           {post.title}
         </Typography>
         <div className="mt-5 flex flex-row">
-          <Avatar alt="profile" src={post.writerThumbnailPath} className="mr-3 !h-10 !w-10 object-cover" />
+          <ServerAvatar thumbnailPath={post.writerThumbnailPath} className="mr-3 !h-10 !w-10" />
           <div className="flex flex-col">
             <Typography variant="paragraph">{post.writerName}</Typography>
             <Typography className="!text-[12px] text-subGray">

--- a/src/pages/rank/Rank.tsx
+++ b/src/pages/rank/Rank.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Avatar, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { AttendRankInfo, GameRankInfo } from '@api/dto';
 import {
   useGetContinuousAttendanceRank,
@@ -10,6 +10,7 @@ import {
 } from '@api/rankApi';
 import usePagination from '@hooks/usePagination';
 import { formatGeneration } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import StandardTab from '@components/Tab/StandardTab';
 import StandardTable from '@components/Table/StandardTable';
@@ -19,7 +20,10 @@ import TopCard from './TopCard';
 interface AttendRankRow {
   id: number;
   rank: number;
-  realName: string;
+  name: {
+    realName: string;
+    thumbnailPath?: string | null;
+  };
   generation: string;
   totalAttendance: number;
   time: string;
@@ -28,14 +32,17 @@ interface AttendRankRow {
 interface PointRankRow {
   id: number;
   rank: number;
-  realName: string;
+  name: {
+    realName: string;
+    thumbnailPath?: string | null;
+  };
   generation: string;
   point: number;
 }
 
 const attendColumns: Column<AttendRankRow>[] = [
   { key: 'rank', headerName: '랭킹', width: 50 },
-  { key: 'realName', headerName: '이름', width: 100 },
+  { key: 'name', headerName: '이름', width: 100 },
   { key: 'generation', headerName: '기수', width: 100 },
   { key: 'totalAttendance', headerName: '총 출석일', width: 100 },
   { key: 'time', headerName: '출석 시간', width: 150 },
@@ -43,7 +50,7 @@ const attendColumns: Column<AttendRankRow>[] = [
 
 const pointColumns: Column<PointRankRow>[] = [
   { key: 'rank', headerName: '랭킹', width: 50 },
-  { key: 'realName', headerName: '이름', width: 100 },
+  { key: 'name', headerName: '이름', width: 100 },
   { key: 'generation', headerName: '기수', width: 100 },
   { key: 'point', headerName: '포인트', width: 100 },
 ];
@@ -52,11 +59,11 @@ const AttendRankChildComponent = ({ key, value }: ChildComponent<AttendRankRow>)
   switch (key) {
     case 'rank':
       return `${value}등`;
-    case 'realName':
+    case 'name':
       return (
         <div className="flex place-items-center">
-          <Avatar alt="profile" className="mr-2 !h-6 !w-6" />
-          {value}
+          <ServerAvatar className="mr-2 !h-6 !w-6" thumbnailPath={(value as AttendRankRow['name']).thumbnailPath} />
+          {(value as AttendRankRow['name']).realName}
         </div>
       );
     case 'generation':
@@ -72,11 +79,11 @@ const PointRankChildComponent = ({ key, value }: ChildComponent<PointRankRow>) =
   switch (key) {
     case 'rank':
       return `${value}등`;
-    case 'realName':
+    case 'name':
       return (
         <div className="flex place-items-center">
-          <Avatar alt="profile" className="mr-2 !h-6 !w-6" />
-          {value}
+          <ServerAvatar className="mr-2 !h-6 !w-6" thumbnailPath={(value as AttendRankRow['name']).thumbnailPath} />
+          {(value as AttendRankRow['name']).realName}
         </div>
       );
     case 'generation':
@@ -116,6 +123,10 @@ const Rank = () => {
               columns={attendColumns}
               rows={attendRank.content.map((item) => ({
                 id: item.rank,
+                name: {
+                  realName: item.realName,
+                  thumbnailPath: item.thumbnailPath,
+                },
                 ...item,
               }))}
               childComponent={AttendRankChildComponent}
@@ -128,6 +139,10 @@ const Rank = () => {
               rows={pointRank.content.map((item, index) => ({
                 id: getRowNumber({ size: pointRank.size, index }),
                 rank: getRowNumber({ size: pointRank.size, index }),
+                name: {
+                  realName: item.realName,
+                  thumbnailPath: item.thumbnailPath,
+                },
                 ...item,
               }))}
               childComponent={PointRankChildComponent}

--- a/src/pages/rank/TopCard.tsx
+++ b/src/pages/rank/TopCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Avatar, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { formatGeneration } from '@utils/converter';
+import ServerAvatar from '@components/Avatar/ServerAvatar';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface TopCardProps<T extends Record<string, any>> {
@@ -31,7 +32,7 @@ const TopCard = <T extends Record<string, any>>({ item, message, index }: TopCar
               {message}
             </Typography>
           </div>
-          <Avatar alt="profile" className="my-auto !h-16 !w-16" />
+          <ServerAvatar className="my-auto !h-16 !w-16" thumbnailPath={item.thumbnailPath} />
         </div>
       </div>
       <div className="relative left-2 top-2 h-28 w-80 border-2 border-pointBlue" />


### PR DESCRIPTION
## 연관 이슈
- Close #800

## 작업 요약
- 서버 프로필 받아오는 Avatar 공통 컴포넌트로 만들어주었습니다.

## 작업 상세 설명
- Avatar mui 기본 테마 커스텀 했습니다.
- `ServerAvatar` 컴포넌트 만들었습니다.
- 기본에 Mui Avatar 컴포넌트 사용하던 부분 중 서버 프로필 받아오는 부분 공통 컴포넌트 사용으로 변경해주었습니다.
- 게시글 댓글 작성에 본인 프로필 받아오는 거 추가로 처리해주었습니다.
- 랭킹 페이지 썸네일 주소 연결 안 되어 있던 부분 연결해주었습니다.

## 리뷰 요구사항
- 랭킹 쪽에는 현재 api 변경 사항으로 일부분 썸네일 안 뜰 수 있습니다.
  - 랭킹 api에서 썸네일 주소 안 보내주고 있는 부분은 요청해놨고, api만 작성되면 뜨도록 미리 dto 추가해서 짜놓았습니다. @jasper200207 나중에 api 변경되었다고 하면 제대로 뜨는 지 확인만 해보시면 될 것 같습니다!
  - 랭킹 중 게임 랭킹과 포인트 랭킹 썸네일 받아오는 응답 필드 네이밍이 달라서 게임 랭킹 api 응답 필드 변경 요청 해두었습니다. @jasper200207 여기도 마찬가지로 dto 파일 미리 수정해놔서 변경되면 확인만 부탁드립니다!
