### PR TITLE
Feature/스터디 버그 픽스 #806

### DIFF
--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -36,6 +36,7 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
   const [thumbnail, setThumbnail] = useState<Blob | null>(null);
   const [memberInfos, setMemberInfos] = useState<MultiAutoCompleteValue>([]);
   const [linkError, setLinkError] = useState(false);
+  const [etcLinkError, setEtcLinkError] = useState(false);
 
   const headMemberInfo = useRecoilValue(memberState);
   const isEditMode = Boolean(selectedStudyInfo);
@@ -65,6 +66,12 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
   const handleAddActionButtonClick = () => {
     if (!(getValues('gitLink') || getValues('notionLink') || getValues('etcLink'))) {
       setLinkError(true);
+      return;
+    }
+
+    if (!((getValues('etcTitle') && getValues('etcLink')) || (!getValues('etcTitle') && !getValues('etcLink')))) {
+      setEtcLinkError(true);
+      return;
     }
 
     if (!isValid) {
@@ -300,7 +307,7 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                 }}
               />
             </div>
-            <div className="flex flex-col items-center gap-2 sm:flex-row">
+            <div className="flex flex-col items-start gap-2 sm:flex-row">
               <VscLink size={25} className="fill-pointBlue" />
               <Controller
                 name="etcTitle"
@@ -315,6 +322,10 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                       placeholder="ex. Plato"
                       {...field}
                       error={Boolean(error)}
+                      onChange={(e) => {
+                        setEtcLinkError(false);
+                        field.onChange(e);
+                      }}
                       helperText={error?.message}
                       autoFocus
                     />
@@ -340,6 +351,10 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                       placeholder="https://"
                       {...field}
                       error={Boolean(error)}
+                      onChange={(e) => {
+                        setEtcLinkError(false);
+                        field.onChange(e);
+                      }}
                       helperText={error?.message}
                       autoFocus
                     />
@@ -347,6 +362,11 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                 }}
               />
             </div>
+            {etcLinkError && (
+              <Typography variant="small" className="text-center text-subRed">
+                기타 링크를 사용하려면 링크명과 링크 둘 다 입력해야 합니다.
+              </Typography>
+            )}
           </Stack>
         </div>
       </Stack>

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -40,7 +40,12 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
   const headMemberInfo = useRecoilValue(memberState);
   const isEditMode = Boolean(selectedStudyInfo);
 
-  const { control, getValues, reset } = useForm({ mode: 'onBlur' });
+  const {
+    control,
+    getValues,
+    reset,
+    formState: { isValid },
+  } = useForm({ mode: 'onBlur' });
   const { data: studyDetail } = useGetStudyQuery({ studyId: selectedStudyInfo?.studyId ?? -1, enabled: isEditMode });
   const { mutate: addStudy } = useAddStudyMutation();
   const { mutate: editStudy } = useEditStudyMutation();
@@ -61,6 +66,9 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
     if (!(getValues('gitLink') || getValues('notionLink') || getValues('etcLink'))) {
       setLinkError(true);
     }
+
+    if (!isValid) {
+      return;
     }
 
     const newStudyInfo = {

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -352,6 +352,7 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                       {...field}
                       error={Boolean(error)}
                       onChange={(e) => {
+                        setLinkError(false);
                         setEtcLinkError(false);
                         field.onChange(e);
                       }}

--- a/src/pages/Study/Modal/StudyModal.tsx
+++ b/src/pages/Study/Modal/StudyModal.tsx
@@ -35,6 +35,8 @@ interface StudyModalProps {
 const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, currentPeriod }: StudyModalProps) => {
   const [thumbnail, setThumbnail] = useState<Blob | null>(null);
   const [memberInfos, setMemberInfos] = useState<MultiAutoCompleteValue>([]);
+  const [linkError, setLinkError] = useState(false);
+
   const headMemberInfo = useRecoilValue(memberState);
   const isEditMode = Boolean(selectedStudyInfo);
 
@@ -56,6 +58,11 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
   };
 
   const handleAddActionButtonClick = () => {
+    if (!(getValues('gitLink') || getValues('notionLink') || getValues('etcLink'))) {
+      setLinkError(true);
+    }
+    }
+
     const newStudyInfo = {
       title: getValues('studyTitle'),
       information: getValues('studyInformation'),
@@ -224,7 +231,7 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
         <div className="space-y-4">
           <InputLabel className="!font-semibold">
             <span className="mr-1">링크</span>
-            <span className="text-small text-subGray">(1개 이상 링크 필수)</span>
+            <span className={`text-small ${linkError ? 'text-subRed' : 'text-subGray'}`}>(1개 이상 링크 필수)</span>
           </InputLabel>
           <Stack spacing={{ xs: 3, sm: 2 }}>
             <div className="flex flex-col items-center gap-2 sm:flex-row">
@@ -246,6 +253,10 @@ const StudyModal = ({ open, setOpen, selectedStudyInfo, setSelectedStudyInfo, cu
                       className="w-full"
                       placeholder="https://"
                       {...field}
+                      onChange={(e) => {
+                        setLinkError(false);
+                        field.onChange(e);
+                      }}
                       error={Boolean(error)}
                       helperText={error?.message}
                       autoFocus


### PR DESCRIPTION
## 연관 이슈
- Close #806 

## 작업 상세 설명
- 스터디 링크 한 개도 입력 안 한 상태에서 추가 버튼 클릯시 1개 이상 링크 필수 문구 하이라이트 처리해주었습니다.
  <img width="200" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/fa804dd7-40e4-4335-8261-329a649ed5e6">
- 스터디 링크 etc에서 https:// 로 시작해야 한다는 에러문구는 제공하는데 바로 스터디 추가가 되는 버그가 있었는데 인풋 필드 invalid 시에 추가 안 되도록 처리해주었습니다.
- 기타 링크를 사용하려면 링크명과 링크 둘 다 입력해야 하도록 처리해주었습니다.
  <img width="468" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/6f27ec44-79ae-4b38-9879-61c2e12c9256">

## 리뷰 요구사항
- 예상 소요 시간 3분
