### PR TITLE
fix : 세미나 관리 페이지 이동안되는 버그 해결

### DIFF
--- a/src/pages/admin/SeminarManage/Modal/EditSeminarAttendanceModal.tsx
+++ b/src/pages/admin/SeminarManage/Modal/EditSeminarAttendanceModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AttendanceStatus } from '@api/dto';
 import { useEditAttendStatusMutation } from '@api/seminarApi';
+import usePagination from '@hooks/usePagination';
 import StatusTypeSelector from '@pages/admin/SeminarManage/Selector/StatusTypeSelector';
 import StandardInput from '@components/Input/StandardInput';
 import ActionModal from '@components/Modal/ActionModal';
@@ -16,7 +17,12 @@ const EditSeminarAttendanceModal = ({ open, setOpen, attendanceStatus }: AddSemi
   const [excuse, setExcuse] = useState(attendanceStatus.excuse || '');
   const [isValidExcuse, setIsValidExcuse] = useState(false);
 
-  const { mutate: editAttendStatus } = useEditAttendStatusMutation(attendanceStatus.attendanceId);
+  const { page } = usePagination();
+
+  const { mutate: editAttendStatus } = useEditAttendStatusMutation({
+    attendanceId: attendanceStatus.attendanceId,
+    page,
+  });
 
   const isExcuseRequired = () => {
     return statusType === 'PERSONAL' || statusType === 'LATENESS';


### PR DESCRIPTION
 

## 연관 이슈
- Close #808
 
## 작업 요약
- 리액트 쿼리 키에 page부분이 없어서, page를 이동함에도 api가 다시 안불러와지는 문제였음
- 이에 키에 page 추가. 또한 출석상태변경 api 에서도 똑같이 page를 추가해줌,

## 작업 상세 설명
- 1분