### PR TITLE
fix : 기수별 그룹화 및 비회원 색깔 추가

### DIFF
--- a/src/pages/admin/ActiveMemberManage/Button/MemberTypeChangeButton.tsx
+++ b/src/pages/admin/ActiveMemberManage/Button/MemberTypeChangeButton.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useMediaQuery, useTheme } from '@mui/material';
 import OutlinedButton from '@components/Button/OutlinedButton';
 import { MultiAutoCompleteValue } from '@components/Input/AutoComplete';
 import MemberTypeChangeModal from '../Modal/MemberTypeChangeModal';
@@ -14,20 +13,15 @@ const MemberTypeChangeButton = ({ selectedMemberList, setSelectedMemberList }: M
   const [selectedTypeId, setSelectedTypeId] = useState(1);
   const [memberTypeChangeModalOpen, setMemberTypeChangeModalOpenOpen] = useState(false);
 
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-
   const handleButtonClick = (typeId: number) => {
     setSelectedTypeId(typeId);
     if (selectedMemberList.length !== 0) setMemberTypeChangeModalOpenOpen(true);
   };
   return (
-    <div className="mt-2 flex w-full flex-wrap justify-end space-x-[2px] sm:mt-1 sm:space-x-2">
+    <div className="mt-2 flex h-fit w-full flex-wrap items-start justify-end gap-2">
       {memberTypes.map((member) => (
-        <OutlinedButton small={isMobile} key={member.typeId} onClick={() => handleButtonClick(member.typeId)}>
-          {member.color && (
-            <div className={`bg-${member.color} ${isMobile ? 'h-2 w-2' : 'h-4 w-4'} mr-2 rounded-full`} />
-          )}
+        <OutlinedButton key={member.typeId} onClick={() => handleButtonClick(member.typeId)} className="w-36">
+          {member.color && <div className={`bg-${member.color} mr-2 h-4 w-4 rounded-full`} />}
           {member.renderType}
         </OutlinedButton>
       ))}

--- a/src/pages/admin/ActiveMemberManage/Input/MemberTypeChangeInput.tsx
+++ b/src/pages/admin/ActiveMemberManage/Input/MemberTypeChangeInput.tsx
@@ -13,16 +13,18 @@ const MemberTypeChangeInput = ({
   selectedMemberList,
   setSelectedMemberList,
 }: MemberTypeChangeInputProps) => {
+  const options: { value: number; label: string; group: string }[] = [];
+  memberList?.forEach((data) => options.push({ value: data.memberId, label: data.realName, group: data.generation }));
+  const sortedOptions = options.sort((a, b) => (a.group > b.group ? 1 : -1));
+
   return (
     <AutoComplete
       className="w-96"
       value={selectedMemberList}
       multiple
+      grouped
       onChange={setSelectedMemberList}
-      items={memberList?.map((member) => ({
-        value: member.memberId,
-        label: `${member.realName} (${member.generation})`,
-      }))}
+      items={sortedOptions}
     />
   );
 };

--- a/src/pages/admin/ActiveMemberManage/memberTypes.ts
+++ b/src/pages/admin/ActiveMemberManage/memberTypes.ts
@@ -7,9 +7,9 @@ interface memberTypeInfo {
 
 const memberTypes: memberTypeInfo[] = [
   { type: '정회원', renderType: '활동회원', typeId: 2, color: 'pointBlue' },
-  { type: '휴면회원', renderType: '휴면', typeId: 3, color: 'white' },
+  { type: '휴면회원', renderType: '휴면', typeId: 3, color: 'pointBlue/30' },
   { type: '졸업', renderType: '졸업', typeId: 4, color: 'mainBlack' },
-  { type: '비회원', renderType: '비회원', typeId: 1, color: 'pointBlue/20' },
+  { type: '비회원', renderType: '비회원', typeId: 1, color: 'white' },
   { type: '탈퇴', renderType: '탈퇴', typeId: 5, color: '' },
 ];
 

--- a/src/pages/admin/ActiveMemberManage/memberTypes.ts
+++ b/src/pages/admin/ActiveMemberManage/memberTypes.ts
@@ -9,7 +9,7 @@ const memberTypes: memberTypeInfo[] = [
   { type: '정회원', renderType: '활동회원', typeId: 2, color: 'pointBlue' },
   { type: '휴면회원', renderType: '휴면', typeId: 3, color: 'white' },
   { type: '졸업', renderType: '졸업', typeId: 4, color: 'mainBlack' },
-  { type: '비회원', renderType: '비회원', typeId: 1, color: '' },
+  { type: '비회원', renderType: '비회원', typeId: 1, color: 'pointBlue/20' },
   { type: '탈퇴', renderType: '탈퇴', typeId: 5, color: '' },
 ];
 


### PR DESCRIPTION
 

## 연관 이슈
- Close #816

## 작업 요약
- 버튼 크기 통일 
- 버튼 크기 모바일에서 키움
- 오토컴플리트 기수별 그룹화 추가
- 비회원 컬러 추가
<img width="520" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/3c8a4b25-65f9-4e39-844e-6bac69d069cc">


## 리뷰 요구사항
- 5분

## Preview 이미지
<img width="1059" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/0a12f448-d2e5-4e52-8acf-9529282a18c6">
<img width="484" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/9c3ff740-3d66-4026-962e-503dcb17c841">
<img width="300" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/81643702/fa72291a-ecc9-4ca3-83a1-79d63022857f">
