### PR TITLE
fix : 모바일에선 중간 카드를 맨처음에 보여주도록

### DIFF
--- a/src/pages/senimarAttend/SenimarAttend.tsx
+++ b/src/pages/senimarAttend/SenimarAttend.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Typography } from '@mui/material';
+import { VscChevronLeft, VscChevronRight } from 'react-icons/vsc';
 import { useRecoilValue } from 'recoil';
 import { MemberInfo } from '@api/dto';
 import {
@@ -43,7 +44,7 @@ const SeminarAttend = () => {
     return false;
   };
 
-  const [currentCardIndex, setCurrentCardIndex] = useState(0);
+  const [currentCardIndex, setCurrentCardIndex] = useState(1);
 
   const handleNextButtonClick = () => {
     setCurrentCardIndex(currentCardIndex + 1);
@@ -97,10 +98,10 @@ const SeminarAttend = () => {
       </div>
       <div className="flex w-[345px] justify-between md:hidden">
         <OutlinedButton onClick={handlePreviousButtonClick} disabled={currentCardIndex === 0}>
-          이전
+          <VscChevronLeft size={20} />
         </OutlinedButton>
         <OutlinedButton onClick={handleNextButtonClick} disabled={currentCardIndex === visibleSeminars.length - 1}>
-          다음
+          <VscChevronRight size={20} />
         </OutlinedButton>
       </div>
     </div>


### PR DESCRIPTION


## 연관 이슈
- Close #821

## 작업 요약
- 이전, 다음 글자 -> 아이콘으로 변경
- 모바일에선 중간 카드를 맨처음에 보여주도록
