### PR TITLE
Feature/세미나 출석 페이지 버그 픽스 #792

### DIFF
--- a/src/api/seminarApi.ts
+++ b/src/api/seminarApi.ts
@@ -74,6 +74,7 @@ const useStartSeminarMutation = (id: number) => {
   return useMutation(fetcher, {
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: seminarKeys.getAvailableSeminar });
+      queryClient.invalidateQueries({ queryKey: seminarKeys.getSeminar({ id }) });
       return response.data.attendanceCode;
     },
   });

--- a/src/components/Typography/TextTimer.tsx
+++ b/src/components/Typography/TextTimer.tsx
@@ -4,9 +4,10 @@ import { DateTime } from 'luxon';
 
 interface TextTimerProps {
   expirationTime: DateTime;
+  setIsEnd?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TextTimer = ({ expirationTime }: TextTimerProps) => {
+const TextTimer = ({ expirationTime, setIsEnd }: TextTimerProps) => {
   const [remainingSeconds, setRemainingSeconds] = useState(
     Math.floor(expirationTime.diff(DateTime.now()).as('seconds')),
   );
@@ -14,6 +15,7 @@ const TextTimer = ({ expirationTime }: TextTimerProps) => {
   useEffect(() => {
     const interval = setInterval(() => {
       if (remainingSeconds <= 0) {
+        if (setIsEnd) setIsEnd(true);
         clearInterval(interval);
         return;
       }

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -71,14 +71,16 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
             ) : (
               <>
                 <Countdown
-                  startTime={seminarData.openTime}
+                  startTime={seminarData.attendanceStartTime}
                   endTime={seminarData.attendanceCloseTime}
+                  isTransitionTime={isTransitionTime}
                   setIsTransitionTime={setIsTransitionTime}
                 />
                 <Countdown
                   startTime={seminarData.attendanceCloseTime}
                   endTime={seminarData.latenessCloseTime}
                   isTransitionTime={isTransitionTime}
+                  setIsTransitionTime={setIsTransitionTime}
                 />
               </>
             ))}

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -19,6 +19,7 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
   const [attendValue, setAttendValue] = useState<number>(5);
   const [lateAttendValue, setLateAttendValue] = useState<number>(5);
   const [startTime, setStartTime] = useState(DateTime.now());
+  const [isTransitionTime, setIsTransitionTime] = useState(false);
   const { mutate: setSeminarTime } = useStartSeminarMutation(seminarId);
   const { data: availableSeminarData } = useGetAvailableSeminarInfoQuery();
   const member: MemberInfo | null = useRecoilValue(memberState);
@@ -64,10 +65,15 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
             </>
           ) : (
             <>
-              <Countdown startTime={seminarData?.openTime ?? null} endTime={seminarData?.attendanceCloseTime ?? null} />
+              <Countdown
+                startTime={seminarData?.openTime ?? null}
+                endTime={seminarData?.attendanceCloseTime ?? null}
+                setIsTransitionTime={setIsTransitionTime}
+              />
               <Countdown
                 startTime={seminarData?.attendanceCloseTime ?? null}
                 endTime={seminarData?.latenessCloseTime ?? null}
+                isTransitionTime={isTransitionTime}
               />
             </>
           )}

--- a/src/pages/senimarAttend/Card/BossCardContent.tsx
+++ b/src/pages/senimarAttend/Card/BossCardContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Typography } from '@mui/material';
+import { CircularProgress, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { MemberInfo } from '@api/dto';
@@ -15,7 +15,7 @@ import SeminarAttendStatus from '../Status/SeminarAttendStatus';
 const BossCardContent = ({ seminarId }: { seminarId: number }) => {
   const [seminarStart, setSeminarStart] = useState(false);
   const setStartMember = useSetRecoilState<number | undefined>(starterState);
-  const { data: seminarData } = useGetSeminarInfoQuery(seminarId);
+  const { data: seminarData, isLoading } = useGetSeminarInfoQuery(seminarId);
   const [attendValue, setAttendValue] = useState<number>(5);
   const [lateAttendValue, setLateAttendValue] = useState<number>(5);
   const [startTime, setStartTime] = useState(DateTime.now());
@@ -42,7 +42,11 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
     }
   }, [seminarData, availableSeminarData]);
 
-  return (
+  return isLoading ? (
+    <div className="flex h-full items-center">
+      <CircularProgress />
+    </div>
+  ) : (
     <>
       <Typography className="!mt-[16px] !text-h3 !font-bold ">{seminarData?.name} 세미나</Typography>
       <p className="mb-[14px] mt-[26px]">출석 코드</p>
@@ -58,25 +62,26 @@ const BossCardContent = ({ seminarId }: { seminarId: number }) => {
           <div>지각</div>
         </div>
         <div className="grid content-between text-right">
-          {!seminarStart && seminarData && !seminarData.attendanceStartTime ? (
-            <>
-              <SeminarSelector limitValue={attendValue} setLimitValue={setAttendValue} />
-              <SeminarSelector limitValue={lateAttendValue} setLimitValue={setLateAttendValue} />
-            </>
-          ) : (
-            <>
-              <Countdown
-                startTime={seminarData?.openTime ?? null}
-                endTime={seminarData?.attendanceCloseTime ?? null}
-                setIsTransitionTime={setIsTransitionTime}
-              />
-              <Countdown
-                startTime={seminarData?.attendanceCloseTime ?? null}
-                endTime={seminarData?.latenessCloseTime ?? null}
-                isTransitionTime={isTransitionTime}
-              />
-            </>
-          )}
+          {seminarData &&
+            (!seminarData.attendanceStartTime ? (
+              <>
+                <SeminarSelector limitValue={attendValue} setLimitValue={setAttendValue} />
+                <SeminarSelector limitValue={lateAttendValue} setLimitValue={setLateAttendValue} />
+              </>
+            ) : (
+              <>
+                <Countdown
+                  startTime={seminarData.openTime}
+                  endTime={seminarData.attendanceCloseTime}
+                  setIsTransitionTime={setIsTransitionTime}
+                />
+                <Countdown
+                  startTime={seminarData.attendanceCloseTime}
+                  endTime={seminarData.latenessCloseTime}
+                  isTransitionTime={isTransitionTime}
+                />
+              </>
+            ))}
         </div>
       </div>
       <div className="mt-[39px] flex justify-center">

--- a/src/pages/senimarAttend/Card/MemberCardContent.tsx
+++ b/src/pages/senimarAttend/Card/MemberCardContent.tsx
@@ -26,6 +26,8 @@ const MemberCardContent = ({ seminarId }: { seminarId: number }) => {
   const [inputCode, setInputCode] = useState('');
   const [attendStatus, setAttendStatus] = useState<undefined | SeminarStatus>(undefined);
   const [excessModalOpen, setExcessModalOpen] = useState(false);
+  const [isTransitionTime, setIsTransitionTime] = useState(false);
+
   const { data: availableSeminarData } = useGetAvailableSeminarInfoQuery();
   const isValidActivityStatus = (value: SeminarStatus) => {
     return value === 'ATTENDANCE' || value === 'LATENESS' || value === 'ABSENCE' || value === 'BEFORE_ATTENDANCE';
@@ -97,8 +99,16 @@ const MemberCardContent = ({ seminarId }: { seminarId: number }) => {
         <div className="grid content-between text-right">
           {seminarData && (
             <>
-              <Countdown startTime={seminarData.attendanceStartTime} endTime={seminarData.attendanceCloseTime} />
-              <Countdown startTime={seminarData.attendanceCloseTime} endTime={seminarData.latenessCloseTime} />
+              <Countdown
+                startTime={seminarData.attendanceStartTime}
+                endTime={seminarData.attendanceCloseTime}
+                setIsTransitionTime={setIsTransitionTime}
+              />
+              <Countdown
+                startTime={seminarData.attendanceCloseTime}
+                endTime={seminarData.latenessCloseTime}
+                isTransitionTime={isTransitionTime}
+              />
             </>
           )}
         </div>

--- a/src/pages/senimarAttend/Card/MemberCardContent.tsx
+++ b/src/pages/senimarAttend/Card/MemberCardContent.tsx
@@ -102,12 +102,14 @@ const MemberCardContent = ({ seminarId }: { seminarId: number }) => {
               <Countdown
                 startTime={seminarData.attendanceStartTime}
                 endTime={seminarData.attendanceCloseTime}
+                isTransitionTime={isTransitionTime}
                 setIsTransitionTime={setIsTransitionTime}
               />
               <Countdown
                 startTime={seminarData.attendanceCloseTime}
                 endTime={seminarData.latenessCloseTime}
                 isTransitionTime={isTransitionTime}
+                setIsTransitionTime={setIsTransitionTime}
               />
             </>
           )}

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -14,6 +14,7 @@ const Countdown = ({ startTime, endTime, isTransitionTime, setIsTransitionTime }
   const [text, setText] = useState<string | JSX.Element>('--:--');
 
   const getRenderCountdownText = () => {
+    if (setIsTransitionTime) setIsTransitionTime(false);
     const now = DateTime.now();
 
     if (!startTime || !endTime) {

--- a/src/pages/senimarAttend/Countdown/Countdown.tsx
+++ b/src/pages/senimarAttend/Countdown/Countdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { DateTime } from 'luxon';
 import TextTimer from '@components/Typography/TextTimer';
@@ -6,10 +6,14 @@ import TextTimer from '@components/Typography/TextTimer';
 interface countdownProps {
   startTime: DateTime | null;
   endTime: DateTime | null;
+  isTransitionTime?: boolean;
+  setIsTransitionTime?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Countdown = ({ startTime, endTime }: countdownProps) => {
-  const renderCountdownText = () => {
+const Countdown = ({ startTime, endTime, isTransitionTime, setIsTransitionTime }: countdownProps) => {
+  const [text, setText] = useState<string | JSX.Element>('--:--');
+
+  const getRenderCountdownText = () => {
     const now = DateTime.now();
 
     if (!startTime || !endTime) {
@@ -22,10 +26,14 @@ const Countdown = ({ startTime, endTime }: countdownProps) => {
       return '마감';
     }
 
-    return <TextTimer expirationTime={endTime} />;
+    return <TextTimer expirationTime={endTime} setIsEnd={setIsTransitionTime} />;
   };
 
-  return <div>{renderCountdownText()}</div>;
+  useEffect(() => {
+    setText(getRenderCountdownText());
+  }, [startTime, endTime, isTransitionTime]);
+
+  return <div>{text}</div>;
 };
 
 export default Countdown;

--- a/src/pages/senimarAttend/SenimarAttend.tsx
+++ b/src/pages/senimarAttend/SenimarAttend.tsx
@@ -78,7 +78,7 @@ const SeminarAttend = () => {
             >
               <SeminarCard>
                 {visibleSeminar.id !== undefined ? (
-                  <div>
+                  <div className="h-full">
                     {isStarterMember() ? (
                       <BossCardContent seminarId={visibleSeminar.id} />
                     ) : (


### PR DESCRIPTION
## 연관 이슈
- #792

## 작업 상세 설명
- 출석이 끝난 후 지각 카운트 다운이 화면 상 바로 흐르지 않는 버그 출석 끝난 기점 trigger를 사용해 해결하였습니다.
- 세미나 시작 시 출석 전 상태로 유지되는 버그 시작 시 세미나 조회 정보 업데이트 해주어 해결하였습니다.
- 타이머 마감으로 변하지 않는 버그도 타이머 끝난 기점 trigger를 사용해 해결하였습니다.
- 카드에 로딩 상태 추가해주었습니다.