### PR TITLE
Feature/sign up api 쿼리키 포맷 통일 #863

### DIFF
--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -3,9 +3,9 @@ import axios from 'axios';
 import { SignUpDuplication, SignUpInfo } from './dto';
 
 export const signUpKeys = {
-  idDuplication: (loginId: string) => ['sighUp', 'duplication', 'loginId', loginId] as const,
-  emailDuplication: (email: string) => ['sighUp', 'duplication', 'email', email] as const,
-  studentIdDuplication: (studentId: string) => ['sighUp', 'duplication', 'studentId', studentId] as const,
+  idDuplication: (params: { loginId: string }) => ['sighUp', 'duplication', 'loginId', params] as const,
+  emailDuplication: (params: { email: string }) => ['sighUp', 'duplication', 'email', params] as const,
+  studentIdDuplication: (params: { studentId: string }) => ['sighUp', 'duplication', 'studentId', params] as const,
 };
 
 const useSignUpMutation = () => {
@@ -21,21 +21,24 @@ const useEmailAuthMutation = () => {
 };
 
 const useCheckLoginIdDuplicationQuery = ({ loginId, enabled }: { loginId: string; enabled: boolean }) => {
-  const fetcher = () => axios.get('/sign-up/exists/login-id', { params: { loginId } }).then(({ data }) => data);
+  const params = { loginId };
+  const fetcher = () => axios.get('/sign-up/exists/login-id', { params }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.idDuplication(loginId), fetcher, { enabled });
+  return useQuery<SignUpDuplication>(signUpKeys.idDuplication(params), fetcher, { enabled });
 };
 
 const useCheckEmailDuplicationQuery = ({ email, enabled }: { email: string; enabled: boolean }) => {
-  const fetcher = () => axios.get('/sign-up/exists/email', { params: { email } }).then(({ data }) => data);
+  const params = { email };
+  const fetcher = () => axios.get('/sign-up/exists/email', { params }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.emailDuplication(email), fetcher, { enabled });
+  return useQuery<SignUpDuplication>(signUpKeys.emailDuplication(params), fetcher, { enabled });
 };
 
 const useCheckStudentIdDuplicationQuery = ({ studentId, enabled }: { studentId: string; enabled: boolean }) => {
-  const fetcher = () => axios.get('/sign-up/exists/student-id', { params: { studentId } }).then(({ data }) => data);
+  const params = { studentId };
+  const fetcher = () => axios.get('/sign-up/exists/student-id', { params }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.studentIdDuplication(studentId), fetcher, { enabled });
+  return useQuery<SignUpDuplication>(signUpKeys.studentIdDuplication(params), fetcher, { enabled });
 };
 
 export {

--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -3,9 +3,11 @@ import axios from 'axios';
 import { SignUpDuplication, SignUpInfo } from './dto';
 
 export const signUpKeys = {
-  idDuplication: (params: { loginId: string }) => ['sighUp', 'duplication', 'loginId', params] as const,
-  emailDuplication: (params: { email: string }) => ['sighUp', 'duplication', 'email', params] as const,
-  studentIdDuplication: (params: { studentId: string }) => ['sighUp', 'duplication', 'studentId', params] as const,
+  base: ['sighUp'] as const,
+  duplication: () => [...signUpKeys.base, 'exists'] as const,
+  loginIdDuplication: (params: { loginId: string }) => [...signUpKeys.duplication(), 'loginId', params] as const,
+  emailDuplication: (params: { email: string }) => [...signUpKeys.duplication(), 'email', params] as const,
+  studentIdDuplication: (params: { studentId: string }) => [...signUpKeys.duplication(), 'studentId', params] as const,
 };
 
 const useSignUpMutation = () => {
@@ -24,7 +26,7 @@ const useCheckLoginIdDuplicationQuery = ({ loginId, enabled }: { loginId: string
   const params = { loginId };
   const fetcher = () => axios.get('/sign-up/exists/login-id', { params }).then(({ data }) => data);
 
-  return useQuery<SignUpDuplication>(signUpKeys.idDuplication(params), fetcher, { enabled });
+  return useQuery<SignUpDuplication>(signUpKeys.loginIdDuplication(params), fetcher, { enabled });
 };
 
 const useCheckEmailDuplicationQuery = ({ email, enabled }: { email: string; enabled: boolean }) => {

--- a/src/pages/Profile/Modal/EditAccountModal.tsx
+++ b/src/pages/Profile/Modal/EditAccountModal.tsx
@@ -257,7 +257,7 @@ const EditPasswordSection = () => {
           rules={{
             required: COMMON.error.required,
             validate: {
-              confirmMatchPassward: (value) => {
+              confirmMatchPassword: (value) => {
                 if (getValues('newPassword') !== value) return CONFIRM_PASSWORD_MSG.error.mismatch;
                 setPasswordConfirmSuccessMsg(CONFIRM_PASSWORD_MSG.success.match);
                 return undefined;

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -140,7 +140,7 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
         rules={{
           required: COMMON.error.required,
           validate: {
-            confirmMatchPassward: (value) => {
+            confirmMatchPassword: (value) => {
               if (getValues('password') !== value) return CONFIRM_PASSWORD_MSG.error.mismatch;
               setPasswordConfirmSuccessMsg(CONFIRM_PASSWORD_MSG.success.match);
               return undefined;

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -18,6 +18,7 @@ interface SignUpFirstInputSectionProps {
 }
 
 const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProps) => {
+  // REVIEW useForm 사용하는데 별도의 state가 필요한 지 점검 필요
   const [loginIdState, setLoginIdState] = useState('');
   const [checkLoginIdDuplicateEnabled, setCheckLoginIdDuplicateEnabled] = useState(false);
   const [passwordConfirmSuccessMsg, setPasswordConfirmSuccessMsg] = useState<string>('');
@@ -62,7 +63,7 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
 
     if (isLoginIdDuplicate.duplicate === false) {
       setCheckLoginIdDuplicateEnabled(false);
-      queryClient.setQueryData(signUpKeys.idDuplication(loginIdState), undefined);
+      queryClient.setQueryData(signUpKeys.idDuplication({ loginId: loginIdState }), undefined);
     }
   }, [watch('loginId')]);
 

--- a/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpFirstInputSection.tsx
@@ -63,7 +63,7 @@ const SignUpFirstInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProp
 
     if (isLoginIdDuplicate.duplicate === false) {
       setCheckLoginIdDuplicateEnabled(false);
-      queryClient.setQueryData(signUpKeys.idDuplication({ loginId: loginIdState }), undefined);
+      queryClient.setQueryData(signUpKeys.loginIdDuplication({ loginId: loginIdState }), undefined);
     }
   }, [watch('loginId')]);
 

--- a/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
+++ b/src/pages/SignUp/Section/SignUpSecondInputSection.tsx
@@ -20,6 +20,7 @@ interface SignUpFirstInputSectionProps {
 }
 
 const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionProps) => {
+  // REVIEW useForm 사용하는데 별도의 state가 필요한 지 점검 필요
   const [studentIdState, setStudentIdState] = useState('');
   const [checkStudentIdDuplicateEnabled, setCheckStudentIdDuplicateEnabled] = useState(false);
   const setSignUpPageState = useSetRecoilState(signUpPageState);
@@ -68,7 +69,7 @@ const SignUpSecondInputSection = ({ setCurrentStep }: SignUpFirstInputSectionPro
 
     if (isStudentIdDuplicate.duplicate === false) {
       setCheckStudentIdDuplicateEnabled(false);
-      queryClient.setQueryData(signUpKeys.studentIdDuplication(studentIdState), undefined);
+      queryClient.setQueryData(signUpKeys.studentIdDuplication({ studentId: studentIdState }), undefined);
     }
   }, [watch('studentId')]);
 


### PR DESCRIPTION
## 연관 이슈
- Close #863

## 작업 요약
- sign up api 쿼리키 포맷 통일해주었습니다.

## 작업 상세 설명
**(✅는 변경 후 정상동작 확인한 사항입니다!)**

- 포맷 통일
  - ✅ 로그인 중복 확인(`useCheckLoginIdDuplicationQuery`)
  - ✅ 이메일 중복 확인(`useCheckEmailDuplicationQuery`)
  - ✅ 학번 중복 확인(`useCheckStudentIdDuplicationQuery`)
- 오타 수정
  - ✅ 회원가입 시 비밀번호 확인란 일치 여부  검증
  - ✅ 계정 변경 시 새 비밀번호 확인란 일치 여부  검증

## To 리뷰어
- 리팩토링하다가 개선 필요해보이는 부분 `REVIEW` 앵커로 주석 달아두었습니다. 언제 한 번 리팩토링 주제로 `REVIEW`, `TODO` 앵커 해결하기 넣어두어도 좋을 것  같아요!
- params 변수 빼는 방식 이렇게 하면 될 지 확인 부탁드려요!