### PR TITLE
Feature/게시글 수정하기 버튼 활성화 안 됨 #880

### DIFF
--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -183,8 +183,10 @@ const useGetEachPostQuery = (
 
 const useGetPostFilesQuery = (postId: number, fileOpen: boolean, password?: string) => {
   const queryClient = useQueryClient();
-
-  const fetcher = () => axios.get(`/posts/${postId}/files`).then(({ data }) => data);
+  const fetcher = () =>
+    axios.get(`/posts/${postId}/files`).then(({ data }) => {
+      return data;
+    });
 
   return useQuery<FileInfo[]>(['files', postId], fetcher, {
     enabled: fileOpen,

--- a/src/pages/board/BoardView/BoardView.tsx
+++ b/src/pages/board/BoardView/BoardView.tsx
@@ -58,7 +58,7 @@ const BoardView = () => {
       {postInfo && (
         <>
           <div className="space-y-2">
-            <BannerSection postId={postId} post={postInfo} />
+            <BannerSection postId={postId} post={postInfo} password={password} />
             <PostSection postId={postId} post={postInfo} password={password} />
           </div>
           <AdjacentPostNavSection previousPost={postInfo.previousPost} nextPost={postInfo.nextPost} />

--- a/src/pages/board/BoardView/Section/BannerSection.tsx
+++ b/src/pages/board/BoardView/Section/BannerSection.tsx
@@ -13,9 +13,10 @@ import ActionModal from '@components/Modal/ActionModal';
 interface BannerSectionProps {
   postId: number;
   post: PostInfo;
+  password?: string;
 }
 
-const BannerSection = ({ postId, post }: BannerSectionProps) => {
+const BannerSection = ({ postId, post, password }: BannerSectionProps) => {
   const [warningDeleteModalopen, setWarningDeleteModalopen] = useState(false);
 
   const { mutate: deletePost } = useDeletePostMutation();
@@ -23,7 +24,7 @@ const BannerSection = ({ postId, post }: BannerSectionProps) => {
   const { checkIsMyId } = useCheckAuth();
 
   const handleEditPostClick = () => {
-    navigate(`/board/write/${post.categoryName}`, { state: { postId, post } });
+    navigate(`/board/write/${post.categoryName}`, { state: { postId, post, password } });
   };
 
   const handleDeletePostClick = () => {

--- a/src/pages/board/BoardView/Section/PostSection.tsx
+++ b/src/pages/board/BoardView/Section/PostSection.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useState } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import { Button, Typography } from '@mui/material';
 import { VscArrowDown, VscArrowUp, VscFolder, VscFolderOpened } from 'react-icons/vsc';
 import { PostInfo } from '@api/dto';
@@ -21,7 +21,7 @@ interface PostSectionProps {
 }
 
 const PostSection = ({ postId, post, password }: PostSectionProps) => {
-  const [fileOpen, toggleFileOpen] = useReducer((prev) => !prev, false);
+  const [fileOpen, toggleFileOpen] = useReducer((prev) => !prev, true);
   const [warningModalOpen, setWarningModalOpen] = useState(false);
   const hasWarningModal = post.categoryName === '시험게시판' && post.isRead === false && !fileOpen;
 
@@ -29,7 +29,6 @@ const PostSection = ({ postId, post, password }: PostSectionProps) => {
   const { mutate: controlLikes } = useControlPostLikesMutation();
   const { mutate: controlDislikes } = useControlPostDislikesMutation();
   const { mutate: downloadFile } = useDownloadFileMutation();
-
   const handleFileOpenButtonClick = () => {
     if (hasWarningModal) {
       setWarningModalOpen(true);
@@ -55,6 +54,11 @@ const PostSection = ({ postId, post, password }: PostSectionProps) => {
   const handleDisikeButtonClick = () => {
     controlDislikes(postId);
   };
+
+  useEffect(() => {
+    handleFileOpenButtonClick();
+    // toggleFileOpen();
+  }, []);
 
   return (
     <div className="min-h-[500px] bg-middleBlack px-6 pb-8 pt-3 sm:px-14 sm:py-10">

--- a/src/pages/board/BoardWrite/BoardWrite.tsx
+++ b/src/pages/board/BoardWrite/BoardWrite.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useQueryClient } from 'react-query';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Stack, Typography } from '@mui/material';
 import { Editor } from '@toast-ui/react-editor';
 import { useRecoilValue } from 'recoil';
-import { FileInfo, PostInfo, UploadPostSettings } from '@api/dto';
+import { PostInfo, UploadPostSettings } from '@api/dto';
 import {
   useAddFilesMutation,
   useDeleteFilesMutation,


### PR DESCRIPTION
## 연관 이슈
> close #880 

## 작업 요약
> 1번, 2번, 2-1번 해결완료

## 작업 상세 설명
> 1. 게시글 수정 페이지에서 글을 수정해도 수정하기 버튼이 활성화되지 않습니다.

- **해결방법** : onBlur() 함수에서 onChange() 함수로 변경해서 input값 변경시에 수정버튼 활성화 되도록 수정했습니다. 
<br/>

> 2. 게시글 수정 페이지에서 새로고침을 하면 첨부파일이 보이지 않습니다. 이후 해당 게시판에서 글 수정 버튼을 눌러도 똑같이 보이지 않습니다.

- **해결방법** : `getQueryData` 로 데이터를 로드하던 방식을 `useGetPostFilesQuery` 함수를 사용하여 데이터를 받아오는 방식으로 수정하였습니다. 
- => `getQueryData` 함수를 사용하면 새로 고침시, 캐싱된 데이터가 날라가기때문에 기존에 저장되어있는 값을 가져오지 못하는 문제가 발생합니다.
- `useGetPostFilesQuery` 함수를 사용하여 새로 고침하더라도 페이지에서 API 함수를 호출해서 데이터를 가져오는 방식으로 변경하여 해결하였습니다. 

<br/>

> 2-1. 새로고침을 해서 첨부파일이 보이지 않게 되었을 때 첨부파일 목록을 열어야 수정할 때 첨부파일이 보입니다.

- **해결방법** : `BoardView` 페이지 로딩시 `fileOpen` 변수의 초기값이 **false**로 설정되어 있어 첨부파일 목록을 펼치지 않으면 파일 데이터를 받아오지 않아 수정버튼을 눌러도 데이터가 전달되지 않았습니다.
- `fileOpen`의 변수 초기값을 **true**로 설정하고 `useEffect()` 함수를 사용하여 페이지 로딩시 첨부파일 목록을 닫게 만들어 사용자가 보기엔 똑같이 첨부파일이 닫혀보이는 상태이지만 데이터는 불러온 상태가 되도록 수정하였습니다.
 

## 리뷰 요구사항
> 10분

