### PR TITLE
Feature/어드민페이지 url로 접근가능 #888

### DIFF
--- a/src/components/NeedAuth/NeedAuth.tsx
+++ b/src/components/NeedAuth/NeedAuth.tsx
@@ -6,10 +6,10 @@ import ConfirmModal from '@components/Modal/ConfirmModal';
 
 interface NeedLoginProps {
   children: JSX.Element;
-  roles: Role[];
+  roles?: Role[];
 }
 
-const NeedAuth = ({ children, roles }: NeedLoginProps) => {
+const NeedAuth = ({ children, roles = [] }: NeedLoginProps) => {
   const { checkIncludeOneOfAuths } = useCheckAuth();
   const navigate = useNavigate();
 
@@ -17,7 +17,7 @@ const NeedAuth = ({ children, roles }: NeedLoginProps) => {
     navigate('/');
   };
 
-  if (checkIncludeOneOfAuths(roles)) {
+  if (checkIncludeOneOfAuths([...roles, 'ROLE_회장', 'ROLE_부회장'])) {
     return children;
   }
   return (

--- a/src/components/NeedAuth/NeedAuth.tsx
+++ b/src/components/NeedAuth/NeedAuth.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Role } from '@api/dto';
 import useCheckAuth from '@hooks/useCheckAuth';
+import ConfirmModal from '@components/Modal/ConfirmModal';
 
 interface NeedLoginProps {
   children: JSX.Element;
@@ -12,16 +13,18 @@ const NeedAuth = ({ children, roles }: NeedLoginProps) => {
   const { checkIncludeOneOfAuths } = useCheckAuth();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!checkIncludeOneOfAuths(roles)) {
-      navigate('/');
-    }
-  }, [checkIncludeOneOfAuths(roles)]);
+  const onClose = () => {
+    navigate('/');
+  };
 
   if (checkIncludeOneOfAuths(roles)) {
     return children;
   }
-  return null;
+  return (
+    <ConfirmModal open onClose={onClose} title="권한이 필요한 서비스입니다">
+      <p>접근 권한이 없습니다</p>
+    </ConfirmModal>
+  );
 };
 
 export default NeedAuth;

--- a/src/components/NeedAuth/NeedAuth.tsx
+++ b/src/components/NeedAuth/NeedAuth.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Role } from '@api/dto';
+import useCheckAuth from '@hooks/useCheckAuth';
+
+interface NeedLoginProps {
+  children: JSX.Element;
+  roles: Role[];
+}
+
+const NeedAuth = ({ children, roles }: NeedLoginProps) => {
+  const { checkIncludeOneOfAuths } = useCheckAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!checkIncludeOneOfAuths(roles)) {
+      navigate('/');
+    }
+  }, [checkIncludeOneOfAuths(roles)]);
+
+  if (checkIncludeOneOfAuths(roles)) {
+    return children;
+  }
+  return null;
+};
+
+export default NeedAuth;

--- a/src/components/NeedAuth/NeedLogin.tsx
+++ b/src/components/NeedAuth/NeedLogin.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import useCheckAuth from '@hooks/useCheckAuth';
+import ConfirmModal from '@components/Modal/ConfirmModal';
 
 interface NeedLoginProps {
   children: JSX.Element;
@@ -10,16 +11,18 @@ const NeedLogin = ({ children }: NeedLoginProps) => {
   const { checkLogin } = useCheckAuth();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!checkLogin()) {
-      navigate('/login');
-    }
-  }, [checkLogin()]);
+  const onClose = () => {
+    navigate('/login');
+  };
 
   if (checkLogin()) {
     return children;
   }
-  return null;
+  return (
+    <ConfirmModal open onClose={onClose} title="로그인이 필요한 서비스입니다">
+      <p>로그인 후 이용해주세요</p>
+    </ConfirmModal>
+  );
 };
 
 export default NeedLogin;

--- a/src/components/NeedAuth/NeedLogin.tsx
+++ b/src/components/NeedAuth/NeedLogin.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useCheckAuth from '@hooks/useCheckAuth';
+
+interface NeedLoginProps {
+  children: JSX.Element;
+}
+
+const NeedLogin = ({ children }: NeedLoginProps) => {
+  const { checkLogin } = useCheckAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!checkLogin()) {
+      navigate('/login');
+    }
+  }, [checkLogin()]);
+
+  if (checkLogin()) {
+    return children;
+  }
+  return null;
+};
+
+export default NeedLogin;

--- a/src/hooks/useCheckAuth.ts
+++ b/src/hooks/useCheckAuth.ts
@@ -6,6 +6,10 @@ import memberState from '@recoil/member.recoil';
 const useCheckAuth = () => {
   const member: MemberInfo | null = useRecoilValue(memberState);
 
+  const checkLogin = useMemo(() => {
+    return () => member !== null;
+  }, [member]);
+
   const checkAuth = useMemo(() => {
     return (requiredRole: Role) => member?.memberJobs?.includes(requiredRole);
   }, [member]);
@@ -16,7 +20,7 @@ const useCheckAuth = () => {
 
   const checkIsMyId = (id: number) => member?.memberId === id;
 
-  return { checkAuth, checkIncludeOneOfAuths, checkIsMyId };
+  return { checkLogin, checkAuth, checkIncludeOneOfAuths, checkIsMyId };
 };
 
 export default useCheckAuth;

--- a/src/router/useMainRouter.tsx
+++ b/src/router/useMainRouter.tsx
@@ -22,6 +22,8 @@ import SeminarAttend from '@pages/senimarAttend/SenimarAttend';
 import FitContainer from '@components/Layout/Container/FitContainer';
 import FullContainer from '@components/Layout/Container/FullContainer';
 import MainLayout from '@components/Layout/MainLayout';
+import NeedAuth from '@components/NeedAuth/NeedAuth';
+import NeedLogin from '@components/NeedAuth/NeedLogin';
 
 const useMainRouter = () =>
   useRoutes([
@@ -54,7 +56,11 @@ const useMainRouter = () =>
             },
             {
               path: 'profile/:memberId/*',
-              element: <Profile />,
+              element: (
+                <NeedLogin>
+                  <Profile />
+                </NeedLogin>
+              ),
             },
           ],
         },
@@ -66,7 +72,11 @@ const useMainRouter = () =>
               children: [
                 {
                   path: 'dutyManage',
-                  element: <DutyManage />,
+                  element: (
+                    <NeedAuth>
+                      <DutyManage />
+                    </NeedAuth>
+                  ),
                 },
                 /* {
                   path: 'electionManage',
@@ -74,19 +84,35 @@ const useMainRouter = () =>
                 }, */
                 {
                   path: 'libraryManage/*',
-                  element: <LibraryManage />,
+                  element: (
+                    <NeedAuth roles={['ROLE_사서']}>
+                      <LibraryManage />
+                    </NeedAuth>
+                  ),
                 },
                 {
                   path: 'seminarManage',
-                  element: <SeminarManage />,
+                  element: (
+                    <NeedAuth roles={['ROLE_서기']}>
+                      <SeminarManage />
+                    </NeedAuth>
+                  ),
                 },
                 {
                   path: 'activeMemberManage',
-                  element: <ActiveMemberManage />,
+                  element: (
+                    <NeedAuth roles={['ROLE_서기']}>
+                      <ActiveMemberManage />
+                    </NeedAuth>
+                  ),
                 },
                 {
                   path: 'meritManage',
-                  element: <MeritManage />,
+                  element: (
+                    <NeedAuth roles={['ROLE_서기']}>
+                      <MeritManage />
+                    </NeedAuth>
+                  ),
                 },
               ],
             },
@@ -95,29 +121,53 @@ const useMainRouter = () =>
               children: [
                 {
                   path: ':categoryName',
-                  element: <BoardList />,
+                  element: (
+                    <NeedLogin>
+                      <BoardList />
+                    </NeedLogin>
+                  ),
                 },
                 {
                   path: 'write/:categoryName',
-                  element: <BoardWrite />,
+                  element: (
+                    <NeedLogin>
+                      <BoardWrite />
+                    </NeedLogin>
+                  ),
                 },
                 {
                   path: 'view/:postId',
-                  element: <BoardView />,
+                  element: (
+                    <NeedLogin>
+                      <BoardView />
+                    </NeedLogin>
+                  ),
                 },
               ],
             },
             {
               path: 'study',
-              element: <Study />,
+              element: (
+                <NeedLogin>
+                  <Study />
+                </NeedLogin>
+              ),
             },
             {
               path: 'library',
-              element: <Library />,
+              element: (
+                <NeedLogin>
+                  <Library />
+                </NeedLogin>
+              ),
             },
             {
               path: 'seminar',
-              element: <SeminarAttend />,
+              element: (
+                <NeedLogin>
+                  <SeminarAttend />
+                </NeedLogin>
+              ),
             },
             /* {
               path: 'election',
@@ -125,11 +175,19 @@ const useMainRouter = () =>
             }, */
             {
               path: 'rank',
-              element: <Rank />,
+              element: (
+                <NeedLogin>
+                  <Rank />
+                </NeedLogin>
+              ),
             },
             {
               path: 'game',
-              element: <Game />,
+              element: (
+                <NeedLogin>
+                  <Game />
+                </NeedLogin>
+              ),
             },
             /* {
               path: 'ctf',


### PR DESCRIPTION
## 연관 이슈
- close #888 

## 작업 요약
어드민페이지 등 권한이 없어도 페이지에 접속되는 문제 해결

## 작업 상세 설명
- NeedLogin, NeedAuth 컴포넌트를 통해 페이지가 렌더링 되기 전 localstorage의 권한을 확인하도록 설정
- 기존에도 api에서 막고 있었기에 프론트에서 경고 띄우기 및 한번 더 거르는 역할

## 리뷰 요구사항
- 리뷰 예상 시간 : 10분

## Preview 이미지

<img width="1684" alt="스크린샷 2024-03-26 오후 3 21 51" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/51306225/e721efc2-72ea-4546-a490-da8d0a890c3c">
<img width="1684" alt="스크린샷 2024-03-26 오후 3 22 11" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/51306225/9b78c855-22c1-4ad5-8d09-569e5ec9b1bf">

