### PR TITLE
Feature/toast UI 이미지 핸들러 #454

### DIFF
--- a/src/api/postApi.ts
+++ b/src/api/postApi.ts
@@ -39,6 +39,22 @@ const useUploadPostMutation = () => {
   return useMutation(fetcher);
 };
 
+const useUploadPostImageMutation = () => {
+  const fetcher = async ({ file }: { file: Blob }) => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const { data } = await axios.post('/posts/files', formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
+    });
+    return data;
+  };
+
+  return useMutation(fetcher);
+};
+
 const useGetPostListQuery = ({ categoryId, searchType, search, page, size }: BoardSearch) => {
   const fetcher = () =>
     axios.get('/posts', { params: { categoryId, searchType, search, page, size } }).then(({ data }) => data);
@@ -251,6 +267,7 @@ const useGetMemberTempPostsQuery = ({ page, size = 10 }: PageAndSize) => {
 
 export {
   useUploadPostMutation,
+  useUploadPostImageMutation,
   useGetPostListQuery,
   useGetRecentPostsQuery,
   useGetTrendPostsQuery,

--- a/src/components/Editor/StandardEditor.tsx
+++ b/src/components/Editor/StandardEditor.tsx
@@ -4,7 +4,7 @@ import { useMediaQuery, useTheme } from '@mui/material';
 import { HookMap } from '@toast-ui/editor';
 import { Editor, EditorProps } from '@toast-ui/react-editor';
 import { useUploadPostImageMutation } from '@api/postApi';
-import { FILE } from '@constants/apiResponseMessage';
+import { FILE, MAX_FILE_SIZE } from '@constants/apiResponseMessage';
 import { getServerImgUrl } from '@utils/converter';
 
 import '@toast-ui/editor/dist/toastui-editor.css';
@@ -21,7 +21,14 @@ const StandardEditor = ({ forwardedRef, ...props }: StandardEditorProps) => {
   const { mutate: uploadPostImageMutation } = useUploadPostImageMutation();
 
   const handleImageUpload: HookMap['addImageBlobHook'] = (blob) => {
-    // TODO: 이미지 크기가 30MB 넘어가면 에러 처리
+    if (blob.size > MAX_FILE_SIZE) {
+      toast.error(FILE.error.exceedFileSize, {
+        style: {
+          maxWidth: 1500,
+        },
+      });
+      return;
+    }
 
     const editor = forwardedRef?.current.getInstance();
     if (!editor) return;

--- a/src/components/Editor/StandardEditor.tsx
+++ b/src/components/Editor/StandardEditor.tsx
@@ -18,14 +18,26 @@ const StandardEditor = ({ forwardedRef, ...props }: StandardEditorProps) => {
 
   const { mutate: uploadPostImageMutation } = useUploadPostImageMutation();
 
-  const handleImageUpload: HookMap['addImageBlobHook'] = (blob, callback) => {
+  const handleImageUpload: HookMap['addImageBlobHook'] = (blob) => {
     // TODO: 이미지 크기가 30MB 넘어가면 에러 처리
-    // TODO: 서버에서 이미지 받아오는 동안 딜레이 처리
+
+    const editor = forwardedRef?.current.getInstance();
+    if (!editor) return;
+
+    const [startPos] = editor.getSelection();
+
+    const IMAGE_MARKDOWN_LOADING_MSG = `![Uploading image...]()`;
+    editor.insertText(IMAGE_MARKDOWN_LOADING_MSG);
+
+    // selection 타입을 명확히 하여 마크다운 위치 계산
+    const [startLinePos, startCharPos] = startPos as Exclude<typeof startPos, number>;
+    const endPos = [startLinePos, startCharPos + IMAGE_MARKDOWN_LOADING_MSG.length] as Exclude<typeof startPos, number>;
+
     uploadPostImageMutation(
       { file: blob },
       {
-        onSuccess: ({ filePath }) => {
-          callback(getServerImgUrl(filePath));
+        onSuccess: ({ fileName, filePath }) => {
+          editor.replaceSelection(`![${fileName}](${getServerImgUrl(filePath)})`, startPos, endPos);
         },
       },
     );

--- a/src/components/Editor/StandardEditor.tsx
+++ b/src/components/Editor/StandardEditor.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
+import { HookMap } from '@toast-ui/editor';
 import { Editor, EditorProps } from '@toast-ui/react-editor';
 
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
+import { useUploadPostImageMutation } from '@api/postApi';
+import { getServerImgUrl } from '@utils/converter';
 
 interface StandardEditorProps extends EditorProps {
   forwardedRef?: React.MutableRefObject<Editor>;
@@ -13,11 +16,29 @@ const StandardEditor = ({ forwardedRef, ...props }: StandardEditorProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
+  const { mutate: uploadPostImageMutation } = useUploadPostImageMutation();
+
+  const handleImageUpload: HookMap['addImageBlobHook'] = (blob, callback) => {
+    // TODO: 이미지 크기가 30MB 넘어가면 에러 처리
+    // TODO: 서버에서 이미지 받아오는 동안 딜레이 처리
+    uploadPostImageMutation(
+      { file: blob },
+      {
+        onSuccess: ({ filePath }) => {
+          callback(getServerImgUrl(filePath));
+        },
+      },
+    );
+  };
+
   return (
     <Editor
       ref={forwardedRef}
       initialValue={props.initialValue ?? ''}
       placeholder="내용을 입력해주세요."
+      hooks={{
+        addImageBlobHook: handleImageUpload,
+      }}
       previewStyle={isMobile ? 'tab' : 'vertical'}
       minHeight="300px"
       initialEditType={isMobile ? 'wysiwyg' : 'markdown'}

--- a/src/components/Editor/StandardEditor.tsx
+++ b/src/components/Editor/StandardEditor.tsx
@@ -36,7 +36,7 @@ const StandardEditor = ({ forwardedRef, ...props }: StandardEditorProps) => {
     const [startPos] = editor.getSelection();
 
     const IMAGE_MARKDOWN_LOADING_MSG = `![Uploading image...]()`;
-    editor.insertText(IMAGE_MARKDOWN_LOADING_MSG);
+    editor.insertText(`${IMAGE_MARKDOWN_LOADING_MSG}\n`);
 
     // selection 타입을 명확히 하여 마크다운 위치 계산
     const [startLinePos, startCharPos] = startPos as Exclude<typeof startPos, number>;

--- a/src/components/Editor/StandardEditor.tsx
+++ b/src/components/Editor/StandardEditor.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import toast from 'react-hot-toast';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { HookMap } from '@toast-ui/editor';
 import { Editor, EditorProps } from '@toast-ui/react-editor';
+import { useUploadPostImageMutation } from '@api/postApi';
+import { FILE } from '@constants/apiResponseMessage';
+import { getServerImgUrl } from '@utils/converter';
 
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
-import { useUploadPostImageMutation } from '@api/postApi';
-import { getServerImgUrl } from '@utils/converter';
 
 interface StandardEditorProps extends EditorProps {
   forwardedRef?: React.MutableRefObject<Editor>;
@@ -38,6 +40,10 @@ const StandardEditor = ({ forwardedRef, ...props }: StandardEditorProps) => {
       {
         onSuccess: ({ fileName, filePath }) => {
           editor.replaceSelection(`![${fileName}](${getServerImgUrl(filePath)})`, startPos, endPos);
+        },
+        onError: () => {
+          editor.deleteSelection(startPos, endPos);
+          toast.error(FILE.error.uploadFail);
         },
       },
     );

--- a/src/constants/apiResponseMessage.ts
+++ b/src/constants/apiResponseMessage.ts
@@ -58,7 +58,7 @@ export const STUDENT_ID = {
   },
 } as const;
 
-export const MAX_FILE_SIZE = 30000000; // Byte
+export const MAX_FILE_SIZE = 30 * 1024 * 1024; // Byte
 export const FILE = {
   success: {},
   error: {

--- a/src/constants/apiResponseMessage.ts
+++ b/src/constants/apiResponseMessage.ts
@@ -1,3 +1,5 @@
+import { formatFileSize } from '@utils/converter';
+
 export const COMMON = {} as const;
 
 export const PASSWORD = {
@@ -56,9 +58,11 @@ export const STUDENT_ID = {
   },
 } as const;
 
+export const MAX_FILE_SIZE = 30000000; // Byte
 export const FILE = {
   success: {},
   error: {
     uploadFail: '업로드가 실패하였습니다.',
+    exceedFileSize: `파일이 제한된 크기(${formatFileSize(MAX_FILE_SIZE)})를 초과하였습니다.`,
   },
 } as const;

--- a/src/constants/apiResponseMessage.ts
+++ b/src/constants/apiResponseMessage.ts
@@ -55,3 +55,10 @@ export const STUDENT_ID = {
     existing: '이미 존재하는 학번입니다.',
   },
 };
+
+export const FILE = {
+  success: {},
+  error: {
+    uploadFail: '업로드가 실패하였습니다.',
+  },
+} as const;

--- a/src/constants/apiResponseMessage.ts
+++ b/src/constants/apiResponseMessage.ts
@@ -47,14 +47,14 @@ export const LOGIN_ID = {
   error: {
     existing: '이미 존재하는 아이디입니다.',
   },
-};
+} as const;
 
 export const STUDENT_ID = {
   success: {},
   error: {
     existing: '이미 존재하는 학번입니다.',
   },
-};
+} as const;
 
 export const FILE = {
   success: {},


### PR DESCRIPTION
## 연관 이슈
- Close #454 

## 작업 요약
- Toast UI 에디터에 이미지 업로드 시 서버에 이미지 저장 후 url 받아와 해당 url의 이미지 띄워주도록 처리

## 작업 상세 설명
- Toast UI 에디터에서 기본적으로 제공하는 이미지 업로드 로직은 파일이 base64로 인코딩되어 삽입되는 형태여서 글자수가 길어져 게시글 전체 글자수 제한에 걸리게 되는 이슈가 있었습니다.
- 서버에 이미지 업로드하여 해당 url로 처리하는 방식으로 변경하여 해당 이슈 해결하였습니다.
- 로딩 처리 및 이미리 업로드 중 텍스트 입력 가능하도록 처리하기 위해 Toast UI Editor에서 기본적으로 제공하는 `addImageBlobHook`의 `callback` 파라미터 사용하는 대신 선택 범위에 텍스트 넣어주는 방식으로 처리하였습니다.
- 파일 사이즈 제한 초과 및 업로드 실패 시 에러 토스트 메시지 띄워주도록 처리하였습니다.

| BEFORE | AFTER |
|--------| --------|
|<img width="534" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/ad6301fd-3a4a-4c04-a7b3-d3ef7a505e40"> | <img width="534" alt="image" src="https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/616cc795-a4b0-4278-891f-a0d6e34298fd">|



## 리뷰 요구사항
- 궁금한 부분 편하게 질문 주셔도 됩니다~!

## Preview

> [!NOTE]
> 로딩 상태 확인을 위해 throttling slow 3g로 맞춰놓고 시연하였습니다. 실제로는 훨씬 빨리 업로드 완료됩니다.

https://github.com/KEEPER31337/Homepage-Front-R2/assets/78250089/a0352737-465d-4255-bcd0-c1526473247d

