### PR TITLE
Feature/검색창의 기수별 정렬 순서 수정

### DIFF
--- a/src/pages/admin/ActiveMemberManage/Input/MemberTypeChangeInput.tsx
+++ b/src/pages/admin/ActiveMemberManage/Input/MemberTypeChangeInput.tsx
@@ -15,7 +15,14 @@ const MemberTypeChangeInput = ({
 }: MemberTypeChangeInputProps) => {
   const options: { value: number; label: string; group: string }[] = [];
   memberList?.forEach((data) => options.push({ value: data.memberId, label: data.realName, group: data.generation }));
-  const sortedOptions = options.sort((a, b) => (a.group > b.group ? 1 : -1));
+  const sortedOptions = options.sort((a, b) => {
+    const aGroup = parseFloat(a.group);
+    const bGroup = parseFloat(b.group);
+    if (aGroup !== bGroup) {
+      return aGroup - bGroup;
+    }
+    return a.label.localeCompare(b.label);
+  });
 
   return (
     <AutoComplete

--- a/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
+++ b/src/pages/admin/DutyManage/Modal/ChangeRolePersonModal.tsx
@@ -29,7 +29,14 @@ const ChangeRolePersonModal = ({ open, toggleOpen, jobName, badgeImage }: Change
 
   const options: { value: number; label: string; group: string }[] = [];
   memberList?.forEach((data) => options.push({ value: data.memberId, label: data.realName, group: data.generation }));
-  const sortedOptions = options.sort((a, b) => (a.group > b.group ? 1 : -1));
+  const sortedOptions = options.sort((a, b) => {
+    const aGroup = parseFloat(a.group);
+    const bGroup = parseFloat(b.group);
+    if (aGroup !== bGroup) {
+      return aGroup - bGroup;
+    }
+    return a.label.localeCompare(b.label);
+  });
 
   const [value, setValue] = useState<SingleAutoCompleteValue>(null);
   const [prevInfo, setPrevInfo] = useState<{ value: number; label: string; group: string }>({


### PR DESCRIPTION
## 연관 이슈
- #892

## 작업 요약
- '활동 회원 관리 페이지'와 '직책 관리 페이지'의 회원 검색창에 뜨는 회원 목록에서, 기수별 순서가 제대로 정렬되지 않고 1, 10, 11, 12 ... 3, 4, 5 순으로 보이는 문제가 발생하여 로직을 다시 구현.

## 작업 상세설명
- group(기수) 값을 정수로 변환하여 sort 메서드를 활용해 오름차순으로 정렬하였습니다.
- 기수가 동일할 경우 localeCompare 메서드를 활용해 알파벳순으로 정렬하였습니다.

## 리뷰 요구사항
> 리뷰 예상 시간 : 1분

## Preview 이미지
